### PR TITLE
improve round time formatting in medtek

### DIFF
--- a/Content.Server/_NF/Medical/HealthAnalyzerPrinterSystem.cs
+++ b/Content.Server/_NF/Medical/HealthAnalyzerPrinterSystem.cs
@@ -141,7 +141,7 @@ public sealed class HealthAnalyzerPrinterSystem : EntitySystem
             { "patient.name", () => GetEntityName(patient) },
             { "patient.species", () => GetEntitySpecies(patient) },
             { "responder.name", () => GetEntityName(responder) },
-            { "roundTime", () => (_gameTiming.CurTime - _gameTicker.RoundStartTimeSpan).ToString(@"hh\:mm") },
+            { "roundTime", () => FormatShiftTime(_gameTiming.CurTime - _gameTicker.RoundStartTimeSpan) },
             { "damageList", () => ComposeDamageList(damageable) },
         };
 
@@ -223,5 +223,15 @@ public sealed class HealthAnalyzerPrinterSystem : EntitySystem
                 ? _prototypes.Index(appearance.Species).Name
                 : "health-analyzer-window-entity-unknown-species-text"
         );
+    }
+
+    private string FormatShiftTime(TimeSpan time)
+    {
+        // Format time to show days if the shift is longer than 24 hours
+        if (time.TotalDays >= 1)
+        {
+            return time.ToString(@"d\:hh\:mm");
+        }
+        return time.ToString(@"hh\:mm");
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Patches Medtek Cart to show DD:HH:MM instead of just HH:MM.
- Would break after 24hr


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [ ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Medtek Printout report will show the proper timestamp with over 24 hour shifts

