### PR TITLE
80% slower needs decay in cyro

### DIFF
--- a/Content.Server/Atmos/Rotting/RottingSystem.cs
+++ b/Content.Server/Atmos/Rotting/RottingSystem.cs
@@ -47,17 +47,20 @@ public sealed class RottingSystem : SharedRottingSystem
     }
 
     /// <summary>
-    /// Is anything speeding up the decay?
-    /// e.g. buried in a grave
+    /// Is anything speeding up or slowing down the decay?
+    /// e.g. buried in a grave (speeds up), or in cryostorage (slows down)
     /// TODO: hot temperatures increase rot?
     /// </summary>
     /// <returns></returns>
     private float GetRotRate(EntityUid uid)
     {
-        if (_container.TryGetContainingContainer((uid, null, null), out var container) &&
-            TryComp<ProRottingContainerComponent>(container.Owner, out var rotContainer))
+        if (_container.TryGetContainingContainer((uid, null, null), out var container))
         {
-            return rotContainer.DecayModifier;
+            if (TryComp<ProRottingContainerComponent>(container.Owner, out var rotContainer))
+                return rotContainer.DecayModifier;
+            
+            if (TryComp<SlowDecayContainerComponent>(container.Owner, out var slowContainer))
+                return slowContainer.DecayModifier;
         }
 
         return 1f;

--- a/Content.Shared/Atmos/Rotting/SlowDecayContainerComponent.cs
+++ b/Content.Shared/Atmos/Rotting/SlowDecayContainerComponent.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Atmos.Rotting;
+
+/// <summary>
+/// Entities inside this container will decay slower (hunger, perishable, etc.)
+/// Useful for cryostorage units and similar stasis containers.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SlowDecayContainerComponent : Component
+{
+    /// <summary>
+    /// The multiplier for decay rates. 0.15 means 85% slower (15% of normal speed).
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float DecayModifier = 0.15f;
+}

--- a/Resources/Prototypes/Entities/Structures/Machines/Medical/cryo_pod.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Medical/cryo_pod.yml
@@ -44,6 +44,8 @@
       beakerSlot: !type:ContainerSlot {}
       machine_board: !type:Container
       machine_parts: !type:Container
+  - type: SlowDecayContainer # Entities inside cryo pods decay 85% slower (hunger, food spoilage, etc.)
+    decayModifier: 0.15
   - type: AtmosDevice
   - type: Appearance
   - type: Machine

--- a/Resources/Prototypes/Entities/Structures/cryogenic_sleep_unit.yml
+++ b/Resources/Prototypes/Entities/Structures/cryogenic_sleep_unit.yml
@@ -43,6 +43,8 @@
   - type: ContainerContainer
     containers:
       storage: !type:ContainerSlot
+  - type: SlowDecayContainer # Entities inside cryogenic sleep units decay 85% slower (hunger, food spoilage, etc.)
+    decayModifier: 0.15
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/cryopod.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/cryopod.yml
@@ -29,6 +29,8 @@
   - type: ContainerContainer
     containers:
       body_container: !type:ContainerSlot
+  - type: SlowDecayContainer # Entities inside cryo sleep chambers decay 85% slower (hunger, food spoilage, etc.)
+    decayModifier: 0.15
 
 # If cryopods get deleted, this one is considered as a safe fallback.
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Implement SlowDecayContainerComponent to reduce decay rates for entities inside.
- Update cryo pod and cryogenic sleep unit prototypes to utilize the new SlowDecayContainer.
- Modify rotting system to account for slow decay effects.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Thirst and hunger decay rate in cyro reduced by 80%