### PR TITLE
Add dumping functionality to ProduceMaterialExtractorSystem

### DIFF
--- a/Content.Server/Materials/ProduceMaterialExtractorSystem.cs
+++ b/Content.Server/Materials/ProduceMaterialExtractorSystem.cs
@@ -22,6 +22,67 @@ public sealed class ProduceMaterialExtractorSystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<ProduceMaterialExtractorComponent, AfterInteractUsingEvent>(OnInteractUsing);
+        SubscribeLocalEvent<ProduceMaterialExtractorComponent, GetDumpableVerbEvent>(OnGetDumpableVerb);
+        SubscribeLocalEvent<ProduceMaterialExtractorComponent, DumpEvent>(OnDump);
+    }
+
+    private void OnGetDumpableVerb(Entity<ProduceMaterialExtractorComponent> ent, ref GetDumpableVerbEvent args)
+    {
+        if (!this.IsPowered(ent, EntityManager))
+            return;
+
+        args.Verb = Loc.GetString("dump-biogenerator-verb-name", ("unit", ent));
+    }
+
+    private void OnDump(Entity<ProduceMaterialExtractorComponent> ent, ref DumpEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (!this.IsPowered(ent, EntityManager))
+            return;
+
+        args.Handled = true;
+
+        bool success = false;
+
+        foreach (var item in args.DumpQueue)
+        {
+            if (TryExtractFromProduce(ent, item, args.User))
+                success = true;
+        }
+
+        if (success)
+        {
+            args.PlaySound = true;
+        }
+    }
+
+    private bool TryExtractFromProduce(Entity<ProduceMaterialExtractorComponent> ent, EntityUid used, EntityUid user)
+    {
+        if (!TryComp<ProduceComponent>(used, out var produce))
+            return false;
+
+        if (!_solutionContainer.TryGetSolution(used, produce.SolutionName, out var solution))
+            return false;
+
+        var matAmount = solution.Value.Comp.Solution.Contents
+            .Where(r => ent.Comp.ExtractionReagents.Contains(r.Reagent.Prototype))
+            .Sum(r => r.Quantity.Float());
+
+        var changed = (int)matAmount;
+
+        if (changed == 0)
+        {
+            _popup.PopupEntity(Loc.GetString("material-extractor-comp-wrongreagent", ("used", used)), user, user);
+            return false;
+        }
+
+        _materialStorage.TryChangeMaterialAmount(ent, ent.Comp.ExtractedMaterial, changed);
+
+        QueueDel(used);
+
+        return true;
     }
 
     // BEGIN Frontier - Cherry pick wizden#32663

--- a/Resources/Locale/en-US/storage/components/dumpable-component.ftl
+++ b/Resources/Locale/en-US/storage/components/dumpable-component.ftl
@@ -2,3 +2,4 @@ dump-verb-name = Dump out on ground
 dump-disposal-verb-name = Dump out into {$unit}
 dump-placeable-verb-name = Dump out onto {$surface}
 dump-smartfridge-verb-name = Restock into {$unit}
+dump-biogenerator-verb-name = Process into {$unit}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Now when you have a plantbag filled with produce and interact with a Biogenerator, you'll see a verb option to "Process into biogenerator".

## Why / Balance
Helps with the grueling task of not being able to dump bags into Biogen.

## Technical details
This works the same way as dumping items into a SmartFridge or Disposal Unit - the plantbag's existing `DumpableComponent` handles the UI and interaction, while the Biogenerator's `ProduceMaterialExtractorComponent` now responds to dump events and processes the items.

## How to test
1. Grab plantbag
2. Dump contents into Biogenerator

## Media
[Screencast_20260111_124535.webm](https://github.com/user-attachments/assets/9139845b-41c7-4142-9a2f-e8b155a47f9e)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Plantbags cant be dumped into Biogenerators (QOL)
