### PR TITLE
Better chat body contrasting color

### DIFF
--- a/Content.Shared/_Coyote/ColorExtensions.cs
+++ b/Content.Shared/_Coyote/ColorExtensions.cs
@@ -13,7 +13,9 @@ public static class ColorExtensions
         {
             input = "bingles"; // Return transparent color for empty or null input
         }
-        // Use a consistent hash function to generate a seed from the input string
+        // Use a deterministic hash function (FNV-1a) to generate a stable seed. 
+        // TODO: Maybe another day once we have time for testing.
+        // int seed = GetDeterministicHashCode(input);
         int seed = input.GetHashCode();
         System.Random random = new(seed);
 
@@ -23,6 +25,26 @@ public static class ColorExtensions
         byte b = (byte)random.Next(0, 256);
 
         return new Color(r, g, b, 255); // A is set to 255 (opaque)
+    }
+
+    /// <summary>
+    /// FNV-1a hash algorithm for deterministic, stable hashing across runs.
+    /// </summary>
+    private static int GetDeterministicHashCode(string str)
+    {
+        unchecked
+        {
+            const int fnvPrime = 16777619;
+            int hash = (int)2166136261;
+
+            foreach (char c in str)
+            {
+                hash ^= c;
+                hash *= fnvPrime;
+            }
+
+            return hash;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Chat coloring with contrast checks werent working right. Rewrote it to be better with checking.

Also, character coloring is hash based which changes on each run. Added eventual `GetDeterministicHashCode` method we can use once we can test it more. Added as todo.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
Before
<img width="575" height="164" alt="image" src="https://github.com/user-attachments/assets/0dc5ba08-8e15-469c-a138-8778f778ca71" />
After
<img width="575" alt="image" src="https://github.com/user-attachments/assets/4ec6f5a6-86d8-43e9-80d2-735ffe183d96" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- tweak: Changed color naming to avoid contrasting issues
