### PR TITLE
Medtek Reinitialises when you get close

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
@@ -39,6 +39,7 @@
                     </BoxContainer>
                     <!-- End Frontier: add print button -->
                 </BoxContainer>
+                <!-- End DeltaV - Medical Records -->
 
                 <PanelContainer StyleClasses="LowDivider" />
 

--- a/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
+++ b/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
@@ -57,6 +57,12 @@ public sealed partial class HealthAnalyzerComponent : Component
     public SoundSpecifier ScanningEndSound = new SoundPathSpecifier("/Audio/Items/Medical/healthscanner.ogg");
 
     /// <summary>
+    /// DeltaV - If the last state of the health analyzer was active.
+    /// </summary>
+    [DataField]
+    public bool IsAnalyzerActive = false;
+
+    /// <summary>
     /// Whether to show up the popup
     /// </summary>
     [DataField]

--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -70,11 +70,12 @@ public sealed class HealthAnalyzerSystem : EntitySystem
             if (component.MaxScanRange != null && !_transformSystem.InRange(patientCoordinates, transform.Coordinates, component.MaxScanRange.Value))
             {
                 //Range too far, disable updates
-                StopAnalyzingEntity((uid, component), patient);
+                PauseAnalyzingEntity((uid, component), patient); // DeltaV - Analyzer Reactivation
                 continue;
             }
 
             UpdateScannedUser(uid, patient, true);
+            component.IsAnalyzerActive = true; // DeltaV - Analyzer Reactivation
         }
     }
 
@@ -178,7 +179,19 @@ public sealed class HealthAnalyzerSystem : EntitySystem
 
         UpdateScannedUser(healthAnalyzer, target, false);
     }
+    /// <summary>
+    /// DeltaV - If the scanner is active, sends one last update and sets it to inactive.
+    /// </summary>
+    /// <param name="healthAnalyzer">The health analyzer that's receiving the updates</param>
+    /// <param name="target">The entity to analyze</param>
+    private void PauseAnalyzingEntity(Entity<HealthAnalyzerComponent> healthAnalyzer, EntityUid target)
+    {
+        if (!healthAnalyzer.Comp.IsAnalyzerActive)
+            return;
 
+        UpdateScannedUser(healthAnalyzer, target, false);
+        healthAnalyzer.Comp.IsAnalyzerActive = false;
+    }
     /// <summary>
     /// Send an update for the target to the healthAnalyzer
     /// </summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Restarts the medscanner if you step away and return to a patient without the need to scan them

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
QoL

## Technical details
<!-- Summary of code changes for easier review. -->
Idk Ness wrote this on her original one, I vaguely understand how the code works:


When one moves out of the scanning range, the scanned entities are no longer set to null. Instead, it will keep checking the range in the Update loop and once they are back within range, it will send an update back to the analyzer. Since setting the scanner to inactive requires you to send the whole payload of health information (found in Content.Shared\MedicalScanner\HealthAnalyzerScannedUserMessage.cs), we also have to save the health analyzer state so that we only send the inactivation once, thus I added IsAnalyzerActive to the HealthAnalyzerComponent that tracks the last state of the health analyzer.

Also fixed the size of the Out of Range sprite to be more consistent with the shitmed sprites found in the analyzer window. It will no longer resize that image if you go out (or back into) range.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Poison some poor Urist and walk away and back

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/26e786ed-d3ce-4178-b6cd-69ad10389b83


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Medscanner becomes active again upon returning to your patient, no more need to rescan

