### PR TITLE
Reverts bees being unable to be swabbed

### DIFF
--- a/Resources/Prototypes/_NF/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/_NF/Hydroponics/seeds.yml
@@ -152,7 +152,7 @@
       Min: 1
       Max: 4
       PotencyDivisor: 25
-  preventSwabbing: true # they're bees
+  # preventSwabbing: true (Wayfarer - False until nets and fishing both get implemented upstream
 
 - type: seed
   id: everyspice


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Reverting a change from https://github.com/new-frontiers-14/frontier-station-14/pull/2993

## Why / Balance
This was originally done in favor of a system that involves using nets and other things (see the Frontier PR), but said system was never implemented.

We can make them unable to be swabbed again when/if said system gets done and gets here.

**Changelog** 🆑

* tweak: Bees can be swabbed again, as weird as that is.