### PR TITLE
Add Ghost Role OOC Examine

### DIFF
--- a/Content.Client/Examine/CharacterExamineSystem.cs
+++ b/Content.Client/Examine/CharacterExamineSystem.cs
@@ -30,6 +30,7 @@ public sealed class CharacterExamineSystem : EntitySystem
 
     private void OnGetExamineVerbs(EntityUid uid, HumanoidAppearanceComponent component, GetVerbsEvent<ExamineVerb> args)
     {
+        // Wayfarer Begin
         args.Verbs.Add(new ExamineVerb
         {
             Text = Loc.GetString("character-examine-verb"),
@@ -39,6 +40,7 @@ public sealed class CharacterExamineSystem : EntitySystem
             ClientExclusive = true,
             ShowOnExamineTooltip = true,
         });
+        // Wayfarer End
     }
 
     private void OnGetExamineVerbsWithMind(EntityUid uid, MindContainerComponent component, GetVerbsEvent<ExamineVerb> args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds the ability to see Ghost Role OOC Freetext if controlled by a player.

## Why / Balance
If a player is playing as a ghost role, it may be relevant to see its OOC Consent Freetext. Whereas before, it was impossible to see that players Consent Freetext.

## Technical details


## How to test
1. Spawn as a ghost role (mothroach, etc)
2. Ensure you have OOC Consent Freetext set
3. Inspect character and ensure you can see the character information button on the tooltip.

## Media
<img width="946" height="715" alt="ss14_moth" src="https://github.com/user-attachments/assets/ec6d1b34-01af-45c7-b90e-ef63ee69f264" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- tweak: Changed the ability to see OOC Freetext on Ghost controlled mobs
