### PR TITLE
Fix shuttle "Drive" and "Park" modes having no damping

### DIFF
--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -62,18 +62,13 @@ namespace Content.Server.Shuttles.Components
         [ViewVariables]
         public DirectionFlag ThrustDirections = DirectionFlag.None;
 
+        // Wayfarer start: Remove 0.0 sentinel value for FTL
         /// <summary>
-        /// Base damping modifier applied to the shuttle's physics component when not in FTL.
-        /// </summary>
-        [DataField]
-        public float BodyModifier = 0.25f;
-
-        /// <summary>
-        /// Final Damping Modifier for a shuttle.
-        /// This value is set to 0 during FTL. And to BodyModifier when not in FTL.
+        /// Damping modifier applied to the shuttle's physics component.
         /// </summary>
         [DataField]
         public float DampingModifier;
+        // Wayfarer end
 
         /// <summary>
         /// Delay between checks to throw on the E-brake.

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.cs
@@ -89,8 +89,8 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
         SubscribeLocalEvent<ShuttleComponent, ComponentStartup>(OnShuttleStartup);
         SubscribeLocalEvent<ShuttleComponent, ComponentShutdown>(OnShuttleShutdown);
         SubscribeLocalEvent<ShuttleComponent, TileFrictionEvent>(OnTileFriction);
-        SubscribeLocalEvent<ShuttleComponent, FTLStartedEvent>(OnFTLStarted);
-        SubscribeLocalEvent<ShuttleComponent, FTLCompletedEvent>(OnFTLCompleted);
+        // SubscribeLocalEvent<ShuttleComponent, FTLStartedEvent>(OnFTLStarted); // Wayfarer: Disable for now
+        // SubscribeLocalEvent<ShuttleComponent, FTLCompletedEvent>(OnFTLCompleted); // Wayfarer: Disable for now
 
         SubscribeLocalEvent<GridInitializeEvent>(OnGridInit);
         NfInitialize(); // Frontier
@@ -128,8 +128,6 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
         {
             Enable(uid, component: physicsComponent, shuttle: component);
         }
-
-        component.DampingModifier = component.BodyModifier;
     }
 
     public void Toggle(EntityUid uid, ShuttleComponent component)
@@ -192,13 +190,16 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
         args.Modifier *= ent.Comp.DampingModifier;
     }
 
-    private void OnFTLStarted(Entity<ShuttleComponent> ent, ref FTLStartedEvent args)
-    {
-        ent.Comp.DampingModifier = 0f;
-    }
-
-    private void OnFTLCompleted(Entity<ShuttleComponent> ent, ref FTLCompletedEvent args)
-    {
-        ent.Comp.DampingModifier = ent.Comp.BodyModifier;
-    }
+    // Wayfarer start: Getting rid of this for now, since we don't have FTL
+    // We can replace this with a simple bool flag if we need it later
+    // private void OnFTLStarted(Entity<ShuttleComponent> ent, ref FTLStartedEvent args)
+    // {
+    //     ent.Comp.DampingModifier = 0f;
+    // }
+    //
+    // private void OnFTLCompleted(Entity<ShuttleComponent> ent, ref FTLCompletedEvent args)
+    // {
+    //     ent.Comp.DampingModifier = ent.Comp.BodyModifier;
+    // }
+    // Wayfarer end
 }

--- a/Content.Server/_NF/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/_NF/Shuttles/Systems/ShuttleSystem.cs
@@ -40,9 +40,9 @@ public sealed partial class ShuttleSystem
     private TimeSpan _nextConsoleCacheRefresh = TimeSpan.Zero;
     private readonly TimeSpan _consoleCacheRefreshInterval = TimeSpan.FromSeconds(30);
 
-    private const float SpaceFrictionStrength = 0.0000f;
-    private const float DampenDampingStrength = 0.25f;
-    private const float AnchorDampingStrength = 2.5f;
+    public const float SpaceFrictionStrength = 0.0000f; // Wayfarer: Zero friction in Cruise mode
+    public const float DampenDampingStrength = 0.25f; // Wayfarer: Public for autopilot
+    public const float AnchorDampingStrength = 2.5f; // Wayfarer: Public for autopilot
     private void NfInitialize()
     {
         SubscribeLocalEvent<ShuttleConsoleComponent, SetInertiaDampeningRequest>(OnSetInertiaDampening);
@@ -70,7 +70,7 @@ public sealed partial class ShuttleSystem
             return false;
         }
 
-        shuttleComponent.BodyModifier = mode switch
+        shuttleComponent.DampingModifier = mode switch // Wayfarer: Set DampingModifier directly
         {
             InertiaDampeningMode.Off => SpaceFrictionStrength,
             InertiaDampeningMode.Dampen => DampenDampingStrength,
@@ -78,8 +78,6 @@ public sealed partial class ShuttleSystem
             _ => DampenDampingStrength, // other values: default to some sane behaviour (assume normal dampening)
         };
 
-        if (shuttleComponent.DampingModifier != 0)
-            shuttleComponent.DampingModifier = shuttleComponent.BodyModifier;
         shuttleComponent.EBrakeActive = false;
         _console.RefreshShuttleConsoles(transform.GridUid.Value);
         return true;
@@ -126,9 +124,9 @@ public sealed partial class ShuttleSystem
         if (shuttle.EBrakeActive)
             return InertiaDampeningMode.Emergency; // mainly to uncheck the thing in the UI
 
-        if (shuttle.BodyModifier >= AnchorDampingStrength)
+        if (shuttle.DampingModifier >= AnchorDampingStrength) // Wayfarer: Set DampingModifier directly
             return InertiaDampeningMode.Anchor;
-        else if (shuttle.BodyModifier <= SpaceFrictionStrength)
+        else if (shuttle.DampingModifier <= SpaceFrictionStrength) // Wayfarer: Set DampingModifier directly
             return InertiaDampeningMode.Off;
         else
             return InertiaDampeningMode.Dampen;

--- a/Content.Server/_WF/Shuttles/Systems/AutopilotSystem.cs
+++ b/Content.Server/_WF/Shuttles/Systems/AutopilotSystem.cs
@@ -107,10 +107,7 @@ public sealed class AutopilotSystem : EntitySystem
                 ApplyBraking(uid, shuttle, physics, xform, frameTime);
 
                 // Park the shuttle by setting it to Anchor mode (same as UI "Park" button)
-                const float AnchorDampingStrength = 2.5f;
-                shuttle.BodyModifier = AnchorDampingStrength;
-                if (shuttle.DampingModifier != 0)
-                    shuttle.DampingModifier = shuttle.BodyModifier;
+                shuttle.DampingModifier = ShuttleSystem.AnchorDampingStrength;
                 shuttle.EBrakeActive = false;
 
                 // Refresh shuttle consoles so pilots see the mode change to "Park"
@@ -695,10 +692,7 @@ public sealed class AutopilotSystem : EntitySystem
         // Switch to "Drive" mode (Dampen) - release any parking brake or anchor
         if (TryComp<ShuttleComponent>(shuttleUid, out var shuttle))
         {
-            const float DampenDampingStrength = 0.25f;
-            shuttle.BodyModifier = DampenDampingStrength;
-            if (shuttle.DampingModifier != 0)
-                shuttle.DampingModifier = shuttle.BodyModifier;
+            shuttle.DampingModifier = ShuttleSystem.DampenDampingStrength;
             shuttle.EBrakeActive = false;
 
             // Refresh shuttle consoles so pilots see the mode change to "Drive"
@@ -716,8 +710,6 @@ public sealed class AutopilotSystem : EntitySystem
             }
         }
     }
-
-    private const float DampenDampingStrength = 0.25f;
 
     /// <summary>
     /// Disable autopilot
@@ -748,9 +740,7 @@ public sealed class AutopilotSystem : EntitySystem
             return;
 
         // Set to Drive (Dampen) mode
-        shuttle.BodyModifier = DampenDampingStrength;
-        if (shuttle.DampingModifier != 0)
-            shuttle.DampingModifier = shuttle.BodyModifier;
+        shuttle.DampingModifier = ShuttleSystem.DampenDampingStrength;
         shuttle.EBrakeActive = false;
 
         // Refresh shuttle consoles so pilots see the mode change


### PR DESCRIPTION
## About the PR
This fixes the shuttle "Drive" and "Park" mode not working once "Cruise" is ever enabled.

## Why / Balance
We want those modes to work as intended while also giving "Cruise" mode zero friction.

## Technical details
This broke because setting the shuttle's damping modifier to 0.0 was being treated as a sentinel value meaning "we're in FTL" and it was getting permanently stuck that way. I removed that check entirely since we haven't reintroduced FTL for player shuttles yet. Once we do, it will make a lot more sense to just use a boolean flag to track whether or not we're in FTL.

## How to test
1. Spawn a shuttle
2. Switch to "Cruise" mode and accelerate
3. See that you never slow down
4. Switch to "Drive" mode
5. See that you slow down gradually
6. Switch to "Park" mode
7. See that you rapidly slow down

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: 
- fix: Fixed shuttle "Drive" and "Park" mode having no damping
