### PR TITLE
Add global interaction verbs and enhance chat messaging for interactions

### DIFF
--- a/Content.Server/InteractionVerbs/InteractionVerbsSystem.cs
+++ b/Content.Server/InteractionVerbs/InteractionVerbsSystem.cs
@@ -1,5 +1,7 @@
 using Content.Server.Chat.Managers;
+using Content.Server.Chat.Systems;
 using Content.Shared.ActionBlocker;
+using Content.Shared.Chat;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
@@ -14,6 +16,7 @@ namespace Content.Server.InteractionVerbs;
 public sealed class InteractionVerbsSystem : SharedInteractionVerbsSystem
 {
     [Dependency] private readonly IChatManager _chatManager = default!;
+    [Dependency] private readonly ChatSystem _chatSystem = default!;
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
     [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
@@ -117,6 +120,13 @@ public sealed class InteractionVerbsSystem : SharedInteractionVerbsSystem
             {
                 var filter = Filter.PvsExcept(args.User).RemoveWhere(s => s.AttachedEntity == args.Target);
                 _popupSystem.PopupEntity(othersMessage, args.Target, filter, true, PopupType.Medium);
+            }
+
+            // Also send the message to chat as an emote
+            if (othersMessage != null)
+            {
+                _chatSystem.TrySendInGameICMessage(args.User, othersMessage, InGameICChatType.Emote, ChatTransmitRange.Normal, 
+                    nameOverride: null, ignoreActionBlocker: true);
             }
         }
 

--- a/Content.Shared/InteractionVerbs/SharedInteractionVerbsSystem.cs
+++ b/Content.Shared/InteractionVerbs/SharedInteractionVerbsSystem.cs
@@ -44,6 +44,36 @@ public abstract class SharedInteractionVerbsSystem : EntitySystem
         );
 
         SubscribeLocalEvent<InteractionVerbsComponent, GetVerbsEvent<InteractionVerb>>(OnGetInteractionVerbs);
+        SubscribeLocalEvent<GetVerbsEvent<InteractionVerb>>(OnGetGlobalInteractionVerbs);
+    }
+
+    private void OnGetGlobalInteractionVerbs(GetVerbsEvent<InteractionVerb> args)
+    {
+        // Skip if entity has InteractionVerbsComponent - those are handled separately
+        if (HasComp<InteractionVerbsComponent>(args.Target))
+            return;
+
+        // Don't show verbs if we can't interact
+        if (!args.CanInteract && !args.CanAccess)
+            return;
+
+        var user = args.User;
+        var target = args.Target;
+        var hasHands = args.Hands != null;
+
+        // Only handle global verbs for entities without InteractionVerbsComponent
+        foreach (var proto in PrototypeManager.EnumeratePrototypes<InteractionVerbPrototype>())
+        {
+            if (!proto.Global)
+                continue;
+
+            if (!IsVerbApplicable(proto, user, target, hasHands, args.CanAccess, args.CanInteract))
+                continue;
+
+            var verb = CreateVerb(proto, user, target, hasHands, args.CanAccess, args.CanInteract);
+            if (verb != null)
+                args.Verbs.Add(verb);
+        }
     }
 
     private void OnGetInteractionVerbs(EntityUid uid, InteractionVerbsComponent component, GetVerbsEvent<InteractionVerb> args)

--- a/Resources/Prototypes/InteractionVerbs/interaction_verbs.yml
+++ b/Resources/Prototypes/InteractionVerbs/interaction_verbs.yml
@@ -169,3 +169,4 @@
   allowSelfInteract: false
   priority: 0
   categoryKey: interaction
+  global: true  # Allow looking at any entity, not just mobs


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Interaction Verbs can now how verbs be globally available (like looking at items), also prints interaction verbs to the chat.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<img width="1297" height="362" alt="image" src="https://github.com/user-attachments/assets/465cdd4c-cfc5-4016-8cee-1817c72a8415" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Interaction verbs print to chat as emote
- tweak: "Look at" verb now works on everything, not just mobs

