### PR TITLE
Fix: Add material refund functionality on Lathe

### DIFF
--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -579,6 +579,30 @@ namespace Content.Server.Lathe
             UpdateRunningAppearance(uid, false);
         }
 
+        /// <summary>
+        /// Refunds materials for unprinted items in a batch
+        /// </summary>
+        private void RefundMaterials(EntityUid uid, LatheComponent component, LatheRecipeBatch batch)
+        {
+            if (!_proto.TryIndex(batch.Recipe, out var recipe))
+                return;
+
+            var unprintedCount = batch.ItemsRequested - batch.ItemsPrinted;
+            if (unprintedCount <= 0)
+                return;
+
+            // Refund materials using the same calculation as consumption (but positive to add back)
+            foreach (var (mat, amount) in recipe.Materials)
+            {
+                var adjustedAmount = recipe.ApplyMaterialDiscount
+                    ? (int)(amount * component.FinalMaterialUseMultiplier)
+                    : amount;
+                adjustedAmount *= unprintedCount;
+
+                _materialStorage.TryChangeMaterialAmount(uid, mat, adjustedAmount);
+            }
+        }
+
         public void OnLatheDeleteRequestMessage(EntityUid uid, LatheComponent component, ref LatheDeleteRequestMessage args)
         {
             if (args.Index < 0 || args.Index >= component.Queue.Count)
@@ -589,6 +613,7 @@ namespace Content.Server.Lathe
                 LogImpact.Low,
                 $"{ToPrettyString(args.Actor):player} deleted a lathe job for ({batch.ItemsPrinted}/{batch.ItemsRequested}) {GetRecipeName(batch.Recipe)} at {ToPrettyString(uid):lathe}");
 
+            RefundMaterials(uid, component, batch);
             component.Queue.RemoveAt(args.Index);
             UpdateUserInterfaceState(uid, component);
         }
@@ -616,6 +641,19 @@ namespace Content.Server.Lathe
             _adminLogger.Add(LogType.Action,
                 LogImpact.Low,
                 $"{ToPrettyString(args.Actor):player} aborted printing {GetRecipeName(_proto.Index(component.CurrentRecipe.GetValueOrDefault()))} at {ToPrettyString(uid):lathe}");
+
+            // Refund materials for the current recipe being aborted
+            if (_proto.TryIndex(component.CurrentRecipe.Value, out var recipe))
+            {
+                foreach (var (mat, amount) in recipe.Materials)
+                {
+                    var adjustedAmount = recipe.ApplyMaterialDiscount
+                        ? (int)(amount * component.FinalMaterialUseMultiplier)
+                        : amount;
+
+                    _materialStorage.TryChangeMaterialAmount(uid, mat, adjustedAmount);
+                }
+            }
 
             component.CurrentRecipe = null;
             FinishProducing(uid, component);


### PR DESCRIPTION
## About the PR
When items were queued in the lathe, materials were immediately consumed. However, if the queue was canceled (either by deleting queued items or aborting the current fabrication), the materials for unprinted items were not being refunded.

Closes #359 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
I added material refund logic in `LatheSystem.cs`

New `RefundMaterials` helper method. This calculates and refunds materials for unprinted items in a batch, using the same formula as material consumption but in reverse (positive amount to add back).

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
[Screencast_20260129_170912.webm](https://github.com/user-attachments/assets/e8ea83df-d4de-42f5-ab44-df1ba176900b)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed cancelling lathe queue refunds materials

