### PR TITLE
Makes .35 and .45 speedloaders tiny

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/pistol35.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/pistol35.yml
@@ -32,6 +32,7 @@
       ballistic-ammo: !type:Container
         ents: []
   - type: Item
+    size: Tiny #Wayfarer: Reduced to Tiny
     sprite: _NF/Objects/Weapons/Guns/Ammunition/SpeedLoaders/Pistol35/speed_loader.rsi
     inhandVisuals:
       left:

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/pistol45.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/pistol45.yml
@@ -32,6 +32,7 @@
       ballistic-ammo: !type:Container
         ents: []
   - type: Item
+    size: Tiny #Wayfarer: Reduced to Tiny
     sprite: _NF/Objects/Weapons/Guns/Ammunition/SpeedLoaders/Pistol45/speed_loader.rsi
     inhandVisuals:
       left:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR makes .35 and .45 speedloaders tiny. Two lines were changed.

## Why / Balance
Revolvers are barely used as they are and there's been a lot of discussion regarding this, personally I think it's fine to have speedloaders be size 1x1, as they are, in fact, quite small and most definitely smaller than a magazine that fits 30 rounds.

This should make people use revolvers a little bit more.

Also.

https://www.youtube.com/watch?v=k4PYRdb71_w

## Technical details
Yaml, 2 lines changed.

## How to test
Get a speedloader, verify that it's 1x1 and not 1x2 anymore.

## Media
<img width="150" height="150" alt="image" src="https://github.com/user-attachments/assets/e73816a7-3f7b-4cad-b1c7-a6205eeb7263" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
- tweak: .35 and .45 speedloaders are now tiny.