### PR TITLE
Matchstick light behavior and properties

### DIFF
--- a/Content.Shared/IgnitionSource/EntitySystems/MatchstickSystem.cs
+++ b/Content.Shared/IgnitionSource/EntitySystems/MatchstickSystem.cs
@@ -63,7 +63,8 @@ public sealed partial class MatchstickSystem : EntitySystem
 
     private void SetState(Entity<MatchstickComponent> ent, SmokableState newState)
     {
-        _lights.SetEnabled(ent, newState == SmokableState.Lit);
+        if (_lights.TryGetLight(ent, out var light))
+            _lights.SetEnabled(ent, newState == SmokableState.Lit, light);
 
         _appearance.SetData(ent, SmokingVisuals.Smoking, newState);
 

--- a/Resources/Prototypes/Entities/Objects/Tools/matches.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/matches.yml
@@ -42,8 +42,9 @@
     temperature: 400.0
   - type: PointLight
     enabled: false
-    radius: 1.1
-    color: darkorange
+    radius: 2.0
+    energy: 2.0
+    color: "#FF8C00"
   - type: Appearance
   - type: BurnStateVisuals
     unlitIcon: match_unlit


### PR DESCRIPTION
## About the PR
Matches cast a dim orange glow of light. This closes #268

## Why / Balance
Why wouldn't it cast light?

## Technical details
Modified SetState() to use TryGetLight() first, then pass the component explicitly to SetEnabled(). This ensures the PointLight component is properly resolved before trying to enable it.

Adjusted PointLight values: Set radius: 2.0 and energy: 2.0 to make the light more visible (up from the default 1.0).

## How to test
1. Light match
2. ???
3. Profit

## Media
[Screencast_20260203_181809.webm](https://github.com/user-attachments/assets/2a9d34bb-8d98-40ae-8a32-1abc1c177728)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed Matches casting light properly
