### PR TITLE
Gives dusk and the cove proper music

### DIFF
--- a/Resources/Prototypes/_NF/Maps/Outpost/frontier.yml
+++ b/Resources/Prototypes/_NF/Maps/Outpost/frontier.yml
@@ -11,6 +11,8 @@
     Dusk:
       stationProto: StandardFrontierStation
       gridComponents:
+      - type: VesselMusic
+        ambientMusicPrototype: ColossusCentralMusic
       - type: VesselInfo # WF
         description: "From the Dusk begins a new dawn."
       components:

--- a/Resources/Prototypes/_NF/PointsOfInterest/cove.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/cove.yml
@@ -33,6 +33,8 @@
     Cove:
       stationProto: RecordsFrontierOutpost
       gridComponents:
+      - type: VesselMusic
+        ambientMusicPrototype: CamelotMusic
       - type: VesselInfo # WF
         description: "The code is more what you'd call 'guidelines' than actual rules." # pirate theme'd for now until outlaws
       components:

--- a/Resources/Prototypes/_WF/Maps/dusk.yml
+++ b/Resources/Prototypes/_WF/Maps/dusk.yml
@@ -10,6 +10,8 @@
     Dusk:
       stationProto: StandardFrontierStation
       gridComponents:
+      - type: VesselMusic
+        ambientMusicPrototype: ColossusCentralMusic
       - type: VesselInfo # WF
         description: "From the Dusk begins a new dawn."
       components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gives Dusk station and the Cove their own VesselMusic component, quite like mono!

## Why / Balance
I noticed they weren't using the unique station music sets.

## Technical details
yaml

## How to test
Go to both POIs, check that they are using unique soundtrack.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**

:cl:
- tweak: Dusk and the den both have unique music
