### PR TITLE
Letting reptilians use markings

### DIFF
--- a/Resources/Prototypes/Species/reptilian.yml
+++ b/Resources/Prototypes/Species/reptilian.yml
@@ -37,7 +37,7 @@
 
 - type: markingPoints
   id: MobReptilianMarkingLimits
-  onlyWhitelisted: true
+  onlyWhitelisted: false
   points:
     Special:
       points: 32 # WF


### PR DESCRIPTION
## About the PR
In this PR, I change the marking whitelist setting for Reptilians so that they can use markings because they previously could use only a few universal markings. Yay!

## Why / Balance
Because lizards shouldn't be exempt from the wonderful world of character customization.

## Technical details
I changed `onlyWhitelisted: true` to `onlyWhitelisted: false` in `Resources/Prototypes/Species/reptilian.yml`.

## How to test
Open the sandbox, use `golobby` to go to the lobby, make a reptilian character and look at the markings. Markings!

## Media
<img width="710" height="478" alt="baby youtube pr" src="https://github.com/user-attachments/assets/3a1bf981-d537-4917-a2f7-326d736c09db" />

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
N/A

**Changelog**
:cl: ayoitslilith
- fix: Reptilians now have the full catalogue of markings.