### PR TITLE
Fix Double Actor Emote Prefix

### DIFF
--- a/Content.Server/InteractionVerbs/InteractionVerbsSystem.cs
+++ b/Content.Server/InteractionVerbs/InteractionVerbsSystem.cs
@@ -122,10 +122,18 @@ public sealed class InteractionVerbsSystem : SharedInteractionVerbsSystem
                 _popupSystem.PopupEntity(othersMessage, args.Target, filter, true, PopupType.Medium);
             }
 
-            // Also send the message to chat as an emote
-            if (othersMessage != null)
+            // Also send the message to chat as an emote using a dedicated key that does NOT include the
+            // actor's name, since the chat system prepends it automatically via chat-manager-entity-me-wrap-message.
+            if (popupProto.EmoteSuffix != null)
             {
-                _chatSystem.TrySendInGameICMessage(args.User, othersMessage, InGameICChatType.Emote, ChatTransmitRange.Normal, 
+                var chatMessage = Loc.GetString($"interaction-{proto.ID}-{prefix.ToString().ToLower()}-{popupProto.EmoteSuffix}-popup",
+                    ("user", args.User),
+                    ("target", args.Target),
+                    ("used", args.Used ?? EntityUid.Invalid),
+                    ("selfTarget", args.User == args.Target),
+                    ("hasUsed", hasUsed));
+
+                _chatSystem.TrySendInGameICMessage(args.User, chatMessage, InGameICChatType.Emote, ChatTransmitRange.Normal,
                     nameOverride: null, ignoreActionBlocker: true);
             }
         }

--- a/Content.Shared/InteractionVerbs/InteractionPopupPrototype.cs
+++ b/Content.Shared/InteractionVerbs/InteractionPopupPrototype.cs
@@ -40,6 +40,14 @@ public sealed partial class InteractionPopupPrototype : IPrototype
     [DataField("others")]
     public string? OthersSuffix = "others";
 
+    /// <summary>
+    ///     Loc suffix for the message sent to the chat log as an emote. Unlike the other suffixes, this string
+    ///     should NOT include the actor's name, since the chat system prepends it automatically.
+    ///     If null, no chat message is sent.
+    /// </summary>
+    [DataField("emote")]
+    public string? EmoteSuffix = null;
+
     public enum Prefix : byte
     {
         Success,

--- a/Resources/Locale/en-US/interaction/verbs.ftl
+++ b/Resources/Locale/en-US/interaction/verbs.ftl
@@ -7,6 +7,7 @@ interaction-Lick-description = Lick your co-worker. What HR?
 interaction-Lick-success-self-popup = You lick {THE($target)}.
 interaction-Lick-success-target-popup = {THE($user)} licks you.
 interaction-Lick-success-others-popup = {THE($user)} licks {THE($target)}.
+interaction-Lick-success-emote-popup = licks {THE($target)}.
 
 # Kiss Interaction
 interaction-Kiss-name = Kiss
@@ -14,6 +15,7 @@ interaction-Kiss-description = A kiss melts the pains away.
 interaction-Kiss-success-self-popup = You kiss {THE($target)}.
 interaction-Kiss-success-target-popup = {THE($user)} kisses you.
 interaction-Kiss-success-others-popup = {THE($user)} kisses {THE($target)}.
+interaction-Kiss-success-emote-popup = kisses {THE($target)}.
 
 # Check Out Interaction
 # Designed to not be seen by others, only you and your target. Plays a subtle effect to catch attention.
@@ -22,6 +24,7 @@ interaction-CheckOut-description = This lets you check someone out on the down l
 interaction-CheckOut-success-self-popup = You are really eyeballing {THE($target)}.
 interaction-CheckOut-success-target-popup = You think that {THE($user)} might be checking you out...
 interaction-CheckOut-success-others-popup = {THE($user)} eyes up {THE($target)}.
+interaction-CheckOut-success-emote-popup = eyes up {THE($target)}.
 
 # Wave Interaction
 interaction-Wave-name = Wave
@@ -38,6 +41,10 @@ interaction-Wave-success-others-popup = { $hasUsed ->
     [true] {THE($user)} waves {THE($used)} at {THE($target)}.
     *[false] {THE($user)} waves at {THE($target)}.
 }
+interaction-Wave-success-emote-popup = { $hasUsed ->
+    [true] waves {THE($used)} at {THE($target)}.
+    *[false] waves at {THE($target)}.
+}
 
 # Hug Interaction
 interaction-Hug-name = Hug
@@ -45,6 +52,7 @@ interaction-Hug-description = A hug a day keeps the psychological horrors beyond
 interaction-Hug-success-self-popup = You hug {THE($target)}.
 interaction-Hug-success-target-popup = {THE($user)} hugs you.
 interaction-Hug-success-others-popup = {THE($user)} hugs {THE($target)}.
+interaction-Hug-success-emote-popup = hugs {THE($target)}.
 
 # Pet Interaction
 interaction-Pet-name = Pet
@@ -52,6 +60,7 @@ interaction-Pet-description = Pet your co-worker to ease their stress.
 interaction-Pet-success-self-popup = You pet {THE($target)} on {POSS-ADJ($target)} head.
 interaction-Pet-success-target-popup = {THE($user)} pets you on your head.
 interaction-Pet-success-others-popup = {THE($user)} pets {THE($target)}.
+interaction-Pet-success-emote-popup = pets {THE($target)}.
 
 # LookAt Interaction
 interaction-LookAt-name = Look at
@@ -59,3 +68,4 @@ interaction-LookAt-description = Take a moment to really look at someone.
 interaction-LookAt-success-self-popup = You look at {THE($target)}.
 interaction-LookAt-success-target-popup = {THE($user)} looks at you.
 interaction-LookAt-success-others-popup = {THE($user)} looks at {THE($target)}.
+interaction-LookAt-success-emote-popup = looks at {THE($target)}.

--- a/Resources/Prototypes/InteractionVerbs/interaction_popups.yml
+++ b/Resources/Prototypes/InteractionVerbs/interaction_popups.yml
@@ -4,3 +4,4 @@
   self: self
   target: target
   others: others
+  emote: emote


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Actor name won't incorrectly show twice in a emote.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
`othersMessage` (e.g., "Randal Aster licks Jane Doe.") was being passed directly to the chat system, which then prepended the name again via chat-manager-entity-me-wrap-message, producing "Randal Aster Randal Aster licks Jane Doe.".

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [ ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: Emoting prefixing actor name twice
-->