### PR TITLE
refactor combat music

### DIFF
--- a/Content.Client/Audio/ContentAudioSystem.AmbientMusic.cs
+++ b/Content.Client/Audio/ContentAudioSystem.AmbientMusic.cs
@@ -14,12 +14,13 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Content.Client.CombatMode;
-using Content.Shared.CombatMode;
 using Robust.Shared.Timing;
 using Content.Shared.NPC.Components;
 using Content.Shared._Mono.CCVar;
 using Content.Shared._Crescent.Vessel;
-using Content.Shared.Ghost;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Weapons.Melee;
+using Content.Shared.Weapons.Ranged.Components;
 
 namespace Content.Client.Audio;
 
@@ -37,6 +38,7 @@ public sealed partial class ContentAudioSystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly CombatModeSystem _combatModeSystem = default!; //CLIENT ONE. WHY ARE THERE 3??
     [Dependency] private readonly SpaceBiomeSystem _spaceBiome = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
 
     //options menu ---
     private static float _volumeSliderAmbient;
@@ -117,6 +119,32 @@ public sealed partial class ContentAudioSystem
         if (!_timing.IsFirstTimePredicted) //otherwise this will tick like 5x faster on client. thanks prediction
             return;
 
+        var player = _player.LocalEntity;
+        if (player == null)
+            return;
+
+        if (_combatMusicToggle) // if cvar is off, don't bother
+        {
+            bool currentCombatState = _combatModeSystem.IsInCombatMode()
+                && _hands.TryGetActiveItem(player.Value, out var item)
+                && (HasComp<MeleeWeaponComponent>(item) || HasComp<GunComponent>(item));
+
+            if (currentCombatState && !_combatWindUpBool) //if combat mode is being turned ON
+            {
+                _combatWindUpBool = true;
+                _combatWindUpTimer = 0;
+                _combatWindDownBool = false;
+                _combatWindDownTimer = 0;
+            }
+            else if (!currentCombatState && !_combatWindDownBool) //if combat mode is being turned OFF
+            {
+                _combatWindDownBool = true;
+                _combatWindDownTimer = 0;
+                _combatWindUpBool = false;
+                _combatWindUpTimer = 0;
+            }
+        }
+
         if (_initialStationMusicBool)
         {
             _initialStationMusicTimer += frameTime;
@@ -163,7 +191,6 @@ public sealed partial class ContentAudioSystem
     {
         SubscribeLocalEvent<SpaceBiomeSwapMessage>(OnBiomeChange);
         SubscribeLocalEvent<PlayerParentChangedMessage>(OnPlayerParentChange);
-        SubscribeLocalEvent<ToggleCombatActionEvent>(OnCombatModeToggle);
 
         SubscribeLocalEvent<LocalPlayerDetachedEvent>(OnPlayerDetach); //in case u die in combatmode
 
@@ -240,28 +267,6 @@ public sealed partial class ContentAudioSystem
     private void SwitchCombatMusic(bool currentCombatState)
     {
         SetMusic(_lastGrid, _lastBiome, currentCombatState);
-    }
-    private void OnCombatModeToggle(ToggleCombatActionEvent ev)
-    {
-        if (_combatMusicToggle == false) // if cvar is off, don't bother
-            return;
-        if (!_timing.IsFirstTimePredicted == true) //needed, because combat mode is predicted, and triggers 7 times otherwise.
-            return;
-        bool currentCombatState = _combatModeSystem.IsInCombatMode();
-        if (currentCombatState) //if combat mode is being turned ON
-        {
-            _combatWindUpBool = true;
-            _combatWindUpTimer = 0;
-            _combatWindDownBool = false;
-            _combatWindDownTimer = 0;
-        }
-        else //if combat mode is being turned OFF
-        {
-            _combatWindDownBool = true;
-            _combatWindDownTimer = 0;
-            _combatWindUpBool = false;
-            _combatWindUpTimer = 0;
-        }
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

combat music now only plays while holding a weapon in your active hand in combat mode

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

this makes it less prone to unwanted triggers

## Technical details
<!-- Summary of code changes for easier review. -->

the original code was event-based, this now refreshes state every tick. it queries both the combat mode state and the active hand's item for the MeleeWeapon or Gun components

technically, this could be a very mild performance penalty every frame from querying entities and components, but i'm not sure there's a proper way to do it as event-driven since we don't have a unique component to query on. open to suggestions.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

enter combat mode with/without a weapon. combat music should always trigger when holding any weapon in your active hand, and otherwise fade out according to the delay in audio settings

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Combat music now only triggers while holding a weapon.