### PR TITLE
Add FTL warning announcement for hauler event

### DIFF
--- a/Content.Server/_WF/StationEvents/Components/HaulerAutopilotRuleComponent.cs
+++ b/Content.Server/_WF/StationEvents/Components/HaulerAutopilotRuleComponent.cs
@@ -69,4 +69,9 @@ public sealed partial class HaulerAutopilotRuleComponent : Component
     /// Tracks which players have already heard the audio (to avoid repeating).
     /// </summary>
     public HashSet<EntityUid> PlayersWhoHeardAudio = new();
+
+    /// <summary>
+    /// Whether the 2-minute FTL warning announcement has already been sent.
+    /// </summary>
+    public bool WarningAnnouncementSent;
 }

--- a/Content.Server/_WF/StationEvents/Events/HaulerAutopilotRule.cs
+++ b/Content.Server/_WF/StationEvents/Events/HaulerAutopilotRule.cs
@@ -43,14 +43,32 @@ public sealed class HaulerAutopilotRuleSystem : StationEventSystem<HaulerAutopil
         base.Update(frameTime);
 
         // Check all active hauler autopilot events
-        var query = EntityQueryEnumerator<HaulerAutopilotRuleComponent, GameRuleComponent>();
-        while (query.MoveNext(out var uid, out var component, out var gameRule))
+        var query = EntityQueryEnumerator<HaulerAutopilotRuleComponent, GameRuleComponent, StationEventComponent>();
+        while (query.MoveNext(out var uid, out var component, out var gameRule, out var stationEvent))
         {
             if (!GameTicker.IsGameRuleActive(uid, gameRule) || component.ShuttleUid == null || !Exists(component.ShuttleUid.Value))
                 continue;
 
             UpdateProximityTracking(component);
+            CheckWarningAnnouncement(uid, component, stationEvent);
         }
+    }
+
+    private void CheckWarningAnnouncement(EntityUid uid, HaulerAutopilotRuleComponent component, StationEventComponent stationEvent)
+    {
+        if (component.WarningAnnouncementSent || stationEvent.EndTime == null)
+            return;
+
+        var timeRemaining = stationEvent.EndTime.Value - _timing.CurTime;
+        if (timeRemaining.TotalSeconds > 120)
+            return;
+
+        component.WarningAnnouncementSent = true;
+        var allPlayersInGame = Filter.Empty().AddWhere(GameTicker.UserHasJoinedGame);
+        ChatSystem.DispatchFilteredAnnouncement(allPlayersInGame,
+            Loc.GetString("station-event-hauler-autopilot-warning-announcement"),
+            playSound: false,
+            colorOverride: stationEvent.StartAnnouncementColor);
     }
 
     private void UpdateProximityTracking(HaulerAutopilotRuleComponent component)

--- a/Resources/Locale/en-US/_WF/station-events/hauler-autopilot.ftl
+++ b/Resources/Locale/en-US/_WF/station-events/hauler-autopilot.ftl
@@ -1,4 +1,5 @@
 # Hauler Autopilot Event
 
 station-event-hauler-autopilot-start-announcement = Long-range sensors have detected an autonomous hauler shuttle entering the sector. The vessel appears to be on autopilot, travelling on a predetermined course.
+station-event-hauler-autopilot-warning-announcement = The autonomous hauler is spooling its FTL drive and will be jumping out of the sector in 2 minutes.
 station-event-hauler-autopilot-end-announcement = The autonomous hauler has left sensor range.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Hauler event will now give a hint that its about to despawn in 2 minutes. Whereas before this was very jarring to suddenly have the hauler yoink out from beneath you.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<img width="632" height="175" alt="image" src="https://github.com/user-attachments/assets/ca56b304-6d24-4b41-8d7d-a5a5a6b6f2b0" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
_Changelog not needed_
