### PR TITLE
Fix Hauler RougeSilicon Exception

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
@@ -877,15 +877,6 @@
     availableModes:
     - FullAuto
     soundGunshot: /Audio/Weapons/Guns/Gunshots/rpgfire.ogg
-  - type: ProjectileBatteryAmmoProvider
-    proto: SpawnMobViscerator
-    fireCost: 100
-  - type: Battery
-    maxCharge: 100
-    startingCharge: 100
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 5
 
 #region Tier 3
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Exceptions no longer throw when MobRogueSiliconBase fires/targets.

`MobRogueSiliconCatcher` has two ammo providers on the same `Gun` entity; `BasicEntityAmmoProvider` (Bola) AND `ProjectileBatteryAmmoProvider` (SpawnMobViscerator). When the NPC fires, both handlers respond to TakeAmmoEvent and each adds 1 ammo, giving `ev.Ammo.Count = 2 > shots (1)`, crashing the assertion.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
_No changelog needed_
