### PR TITLE
Port Wizden #35341 (Decouple Lights from Toggleable Visuals)

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
@@ -37,8 +37,8 @@
       id: blinking
       interpolate: Nearest
       maxDuration: 1.0
-      minValue: 0.1
-      maxValue: 2.0
+      startValue: 0.1
+      endValue: 2.0
       isLooped: true
   - type: ToggleableVisuals
     spriteLayer: light

--- a/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
@@ -37,8 +37,8 @@
       id: blinking
       interpolate: Nearest
       maxDuration: 1.0
-      startValue: 0.1
-      endValue: 2.0
+      minValue: 0.1
+      maxValue: 2.0
       isLooped: true
   - type: ToggleableVisuals
     spriteLayer: light
@@ -66,6 +66,11 @@
   - type: Tag
     tags:
     - WhitelistChameleon
+  - type: HideLayerClothing
+    layers:
+      Hair: HEAD
+      HeadTop: HEAD
+      HeadSide: HEAD
 
 - type: entity
   parent: ClothingHeadHatHardhatBase

--- a/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
@@ -1,37 +1,4 @@
 - type: entity
-  parent: ClothingNeckBase
-  id: ClothingNeckHeadphones
-  name: headphones
-  description: Quality headphones from Drunk Masters, with good sound insulation.
-  components:
-  - type: Sprite
-    sprite: Clothing/Neck/Misc/headphones.rsi
-    layers:
-    - state: icon
-      map: [ "enum.ToggleableVisuals.Layer" ]
-  - type: Clothing
-    equippedPrefix: off
-    sprite: Clothing/Neck/Misc/headphones.rsi
-  - type: ToggleableVisuals
-    spriteLayer: enum.ToggleableVisuals.Layer
-    clothingVisuals:
-      neck:
-      - state: on-equipped-NECK
-  - type: Appearance
-  - type: GenericVisualizer
-    visuals:
-      enum.ToggleableVisuals.Enabled:
-        enum.ToggleableVisuals.Layer:
-          True: {state: icon-on}
-          False: {state: icon}
-  - type: ItemToggle
-    predictable: false
-    soundActivate:
-      path: /Audio/Items/flashlight_on.ogg
-    soundDeactivate:
-      path: /Audio/Items/flashlight_off.ogg
-
-- type: entity
   parent: Clothing
   id: ClothingNeckStethoscope
   name: stethoscope

--- a/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
@@ -1,4 +1,37 @@
 - type: entity
+  parent: ClothingNeckBase
+  id: ClothingNeckHeadphones
+  name: headphones
+  description: Quality headphones from Drunk Masters, with good sound insulation.
+  components:
+  - type: Sprite
+    sprite: Clothing/Neck/Misc/headphones.rsi
+    layers:
+    - state: icon
+      map: [ "enum.ToggleableVisuals.Layer" ]
+  - type: Clothing
+    equippedPrefix: off
+    sprite: Clothing/Neck/Misc/headphones.rsi
+  - type: ToggleableVisuals
+    spriteLayer: enum.ToggleableVisuals.Layer
+    clothingVisuals:
+      neck:
+      - state: on-equipped-NECK
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.ToggleableVisuals.Enabled:
+        enum.ToggleableVisuals.Layer:
+          True: {state: icon-on}
+          False: {state: icon}
+  - type: ItemToggle
+    predictable: false
+    soundActivate:
+      path: /Audio/Items/flashlight_on.ogg
+    soundDeactivate:
+      path: /Audio/Items/flashlight_off.ogg
+
+- type: entity
   parent: Clothing
   id: ClothingNeckStethoscope
   name: stethoscope

--- a/Resources/Prototypes/Entities/Objects/Misc/land_mine.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/land_mine.yml
@@ -76,6 +76,9 @@
     activated: true
     onActivate: false
   - type: Armable
+  - type: Sprite
+    layers:
+    - state: landmine
 
 - type: entity
   name: modular mine
@@ -97,6 +100,9 @@
     activated: true
     onActivate: false
   - type: Armable
+  - type: Sprite
+    layers:
+    - state: landmine
 
 - type: entity
   name: explosive mine
@@ -120,3 +126,6 @@
     activated: true
     onActivate: false
   - type: Armable
+  - type: Sprite
+    layers:
+    - state: landmine


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed headphone music note visuals.

... by doing a refactor wherein I decoupled `ToggleableLightVisuals` from lights.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- Fixes the headphones visuals bug ( resolves #31755 )
- Makes it so that item toggling can change visuals of an entity that doesn't have lights

## Technical details
<!-- Summary of code changes for easier review. -->

- Combine enum keys `ToggleableLightVisuals` and `ToggleVisuals` into `ToggleableVisuals`
- Rename `ToggleableLightVisualsComponent` to `ToggleableVisualsComponent` and `ToggleableLightVisualsSystem` to `ToggleableVisualsSystem`
  - (The `SpriteLayer` field on the component is now required because the old default of `light` doesn't make sense anymore) 
- Make it so that `ToggleableVisualsComponent` works even when there's not a light attached to the entity
  - (Amazingly this seems to have only applied to  Headphones, but I can only imagine there are many other things people would like to do with simple toggleable visuals)
- Explicitly make `ItemTogglePointLightComponent`'s purpose to make `ToggleVisualsComponent` apply to `PointLightComponent`s on the same entity.
  - Add field `ToggleableVisualsColorModulatesLights`, which makes the `Color` appearance value of `ToggleableVisuals` modulate the color of lights on the same entity
  - Lots of prototype updates to uptake the above

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/f790ba0a-fd07-42fb-b541-1831c95e5b7c

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

### `ToggleableLightVisuals` and `ToggleVisuals` replaced by `ToggleableVisuals`

Apply the following replacements:
- `ToggleVisuals.Toggled` -> `ToggleableVisuals.Enabled`
- `ToggleVisuals.Layer` -> `ToggleableVisuals.Layer`
- `ToggleableLightVisuals.Enabled` -> `ToggleableVisuals.Enabled`
- `ToggleableLightVisuals.Color` -> `ToggleableVisuals.Color`

### `ToggleableLightVisualsComponent` replaced by `ToggleableVisualsComponent`
`ToggleableLightVisualsComponent` did some very useful stuff in allowing sprites to change on simple item toggles, however it had a major problem of just not working unless there was also a `PointLightComponent` on the entity as well. This change decouples that, meaning a light isn't needed to get the basic sprite-toggling behavior. But this also means reacting to this change means you need to know if you're toggling just-visuals or light-and-visuals. Also, the `spriteLayer` field no longer has a default.

If you just want to toggle visuals (item icon, in-hand, or equipped) and no light
- Replace `ToggleableLightVisuals` with `ToggleableVisuals` in the yaml.
  - If this component doesn't specify a `spriteLayer` field, add it. The old default was `light`, so just using that is the least disruptive uptake, but it will be confusing to maintain since this usage is unrelated to lights.

If you want to toggle a light and visuals
- Replace `ToggleableLightVisuals` with `ToggleableVisuals` in the yaml.
- Add a `ItemTogglePointLight` component
  - If this component doesn't specify a `spriteLayer` field, add it with the old default value `light`.
  - If the color of the light should change with `ToggleableVisuals.Color` (formerly `ToggleableLightVisuals.Color`), set `ToggleableVisualsColorModulatesLights` on this component to `true`.

##### C# changes
Some public types were renamed, but the component has no behavior and the system has no public API changes.
- `ToggleableLightVisualsComponent` renamed to `ToggleableVisualsComponent`
- `ToggleableLightVisualsSystem` renamed to `ToggleableVisualsSystem`


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Ported Wizden Toggleable Visuals system.