### PR TITLE
Temporarily disable hauler proximity audio playback

### DIFF
--- a/Content.Server/_WF/StationEvents/Components/HaulerAutopilotRuleComponent.cs
+++ b/Content.Server/_WF/StationEvents/Components/HaulerAutopilotRuleComponent.cs
@@ -63,7 +63,7 @@ public sealed partial class HaulerAutopilotRuleComponent : Component
     /// The sound to play when a player stays near the shuttle.
     /// </summary>
     [DataField]
-    public SoundSpecifier ProximitySound = new SoundPathSpecifier("/Audio/_WF/Music/HaulerBreach.ogg");
+    // public SoundSpecifier ProximitySound = new SoundPathSpecifier("/Audio/_WF/Music/HaulerBreach.ogg");
 
     /// <summary>
     /// Tracks which players have already heard the audio (to avoid repeating).

--- a/Content.Server/_WF/StationEvents/Events/HaulerAutopilotRule.cs
+++ b/Content.Server/_WF/StationEvents/Events/HaulerAutopilotRule.cs
@@ -114,7 +114,7 @@ public sealed class HaulerAutopilotRuleSystem : StationEventSystem<HaulerAutopil
                 if (timeNearby >= component.ProximityTimeRequired)
                 {
                     // Play audio to this player
-                    _audio.PlayGlobal(component.ProximitySound, actor.PlayerSession, AudioParams.Default);
+                    // _audio.PlayGlobal(component.ProximitySound, actor.PlayerSession, AudioParams.Default);
                     component.PlayersWhoHeardAudio.Add(playerUid);
                     playersToRemove.Add(playerUid);
                 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Hauler event music removed for the time being. Commented out until it can be toggled and/or added to a volume control.

## Why / Balance
Theres no way to adjust volume or disable. It loud.

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
1. Approach Hauler Event
2. Hauler music wont play

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
_No changelog needed_
