### PR TITLE
Silicon Guardian buffs

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
@@ -991,18 +991,18 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      160: Critical
-      320: Dead
+      400: Critical #Way 160-400 buffed for boss purposes
+      400: Dead #Way 320 - 400 buffed for boss purposes made same as critical due to robot design
   - type: SlowOnDamage
     speedModifierThresholds:
       96: 0.7
       130: 0.5
   - type: HitscanBatteryAmmoProvider
-    proto: NFRedLaserPractice
+    proto: NFRedLightLaser #Way Changed from NFRedLightPractice to NFRedLightLaser now.. this is actually scary and deadly
     fireCost: 10
   - type: Gun
     showExamineText: false
-    fireRate: 8
+    fireRate: 4 #Way halved firerate since damage went from a single point of heat to 12 points of heat...
     minAngle: 1
     maxAngle: 10
     angleIncrease: 1

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
@@ -991,18 +991,18 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      400: Critical #Way 160-400 buffed for boss purposes
-      400: Dead #Way 320 - 400 buffed for boss purposes made same as critical due to robot design
+      380: Critical #Way 160-400 buffed for boss purposes
+      400: Dead #Way 320 - 400 buffed for boss purposes made same as critical
   - type: SlowOnDamage
     speedModifierThresholds:
       96: 0.7
       130: 0.5
   - type: HitscanBatteryAmmoProvider
-    proto: NFRedLightLaser #Way Changed from NFRedLightPractice to NFRedLightLaser now.. this is actually scary and deadly
+    proto: NFRedLightLaser
     fireCost: 10
   - type: Gun
     showExamineText: false
-    fireRate: 4 #Way halved firerate since damage went from a single point of heat to 12 points of heat...
+    fireRate: 3 #Way reduced fire rate due to increase in damage
     minAngle: 1
     maxAngle: 10
     angleIncrease: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the silicon guardian slightly

## Why / Balance
It now no longer fires practice laser shots???? shoots properly lethal lasers damage increase 1 to 14
Increased Crit and Dead HP threseholds so it's about twice as tanky and crits just before death (robots can't feel pain)
Decreased fire rate from 8 to 3. Shoots fairly quick but with damage increase won't just slaughter you instantly.. Fully automatic and not exactly a Gatling laser anymore


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/project-wayfarer/wayfarer-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](https://github.com/project-wayfarer/wayfarer-14/blob/master/AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

