### PR TITLE
ci(labeler): Remove label on merge and close

### DIFF
--- a/.github/workflows/labeler-remover.yml
+++ b/.github/workflows/labeler-remover.yml
@@ -1,0 +1,17 @@
+name: "Labels Remover"
+on:
+  pull_request_target:
+    types: [closed]
+jobs:
+  remove_label:
+    # Do we run when merged? or close AND merge?
+    # if: github.event.pull_request.merged == true
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions-ecosystem/action-remove-labels@v1
+      with:
+        labels: |
+          S: Needs Review
+          S: Untriaged

--- a/.github/workflows/labeler-remover.yml
+++ b/.github/workflows/labeler-remover.yml
@@ -4,8 +4,7 @@ on:
     types: [closed]
 jobs:
   remove_label:
-    # Do we run when merged? or close AND merge?
-    # if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a new CI actions to remove label on PR merge and close

Closes #484 

## Why / Balance
Cleanup the label after it got closed

## How to test
Create a new PR and test if it properly remove label from PR.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/project-wayfarer/wayfarer-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](https://github.com/project-wayfarer/wayfarer-14/blob/master/AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->