### PR TITLE
Disables SSD Asphyxiation

### DIFF
--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -17,6 +17,7 @@ using Content.Shared.EntityEffects;
 using Content.Shared.EntityEffects.EffectConditions;
 using Content.Shared.EntityEffects.Effects;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.SSDIndicator; // Wayfarer, needed to check if something has the component.
 using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
@@ -76,6 +77,9 @@ public sealed class RespiratorSystem : EntitySystem
             respirator.NextUpdate += respirator.AdjustedUpdateInterval;
 
             if (_mobState.IsDead(uid))
+                continue;
+
+            if (TryComp<SSDIndicatorComponent>(uid, out var ssd) && ssd.IsSSD) // Wayfarer: Prevents SSD clients from breathing to prevent offline asphyx deaths.
                 continue;
 
             UpdateSaturation(uid, -(float)respirator.UpdateInterval.TotalSeconds, respirator);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
As the title says.

## Why / Balance
I know this has been a source of a little bit of debate, but honestly, we've tried a lot of things to make this work and unfortunately, nothing has quite worked in Coyote and other places. 

I'm of the opinion that allowing this to affect players that are not online brings nothing to the game other than a loud sigh by medical players that will get nothing out of an interaction, and will then also have to deal with what to do with that player, if their ship is unfit to support life. Better to let medical focus on active players, so they can get actual RP out of those interactions.

...This does also technically come with the added bonus of ssd clients no longer causing stable atmospheres to keep recalculating, so there's also that.

## Technical details
Respirator component now seeks for an ssdindicator component, and if the holder has the isSSD status.

## How to test
Give an empty canister to a client, force them to breathe from it, the client will take asphyxiation damage.
Disconnect that client
Verify they are no longer taking oxyloss or breathing.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/project-wayfarer/wayfarer-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](https://github.com/project-wayfarer/wayfarer-14/blob/master/AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: SSD characters no longer breathe, and thus, do not asphyxiate.
