### PR TITLE
Disables Lootbox Land Mines from Loot Bundles

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/Items/engineering_tables.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/Items/engineering_tables.yml
@@ -185,7 +185,7 @@
     # spawn probabilities skewed towards empty toolboxes to reduce entity spam
     # Electrical
     - !type:GroupSelector
-      weight: 32
+      weight: 33 # Wayfarer: Increased as we had to remove the trapped ones so they don't spawn in bundles.
       children:
       - id: ToolboxElectricalFilled
         weight: 20
@@ -193,7 +193,7 @@
         weight: 80
     # Emergency
     - !type:GroupSelector
-      weight: 32
+      weight: 33 # Wayfarer: See comment above.
       children:
       - id: ToolboxEmergencyFilled
         weight: 20
@@ -201,7 +201,7 @@
         weight: 80
     # Mechanical
     - !type:GroupSelector
-      weight: 32
+      weight: 34 # Wayfarer: See comment above.
       children:
       - id: ToolboxMechanicalFilledAllTools
         weight: 15
@@ -210,12 +210,12 @@
       - id: ToolboxMechanical
         weight: 70
     # Trap
-    - !type:GroupSelector
-      weight: 4
-      children:
-      - id: NFToolboxMineCryo
-      - id: NFToolboxMineExplosive
-      - id: NFToolboxMineFire
+    #- !type:GroupSelector # Wayfarer: Let's not.
+    #  weight: 4
+    #  children:
+    #  - id: NFToolboxMineCryo
+    #  - id: NFToolboxMineExplosive
+    #  - id: NFToolboxMineFire
 # Commented out: buy it from your local SyndiVend
 #    # Syndicate
 #    - !type:GroupSelector


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removes tool box mines from the loot table, so that bundles don't spawn these and insta kill people in certain cases like for example where they may have a stack of glass near or on the same tile.

## Why / Balance
Opening a bundle and dying is generally a bad idea, but such is life when all the tables are nested.

## Technical details
yum feed me the yaml slop

## How to test
Spawn a bunch of miner bundles.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/project-wayfarer/wayfarer-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](https://github.com/project-wayfarer/wayfarer-14/blob/master/AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Removed lootboxmines from the engineering tools generation tables.
