### PR TITLE
Slightly Un-Nerfs Sinks

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/sink.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/sink.yml
@@ -135,4 +135,4 @@
       tank:
         reagents:
         - ReagentId: Water
-          Quantity: 500
+          Quantity: 250 # Wayfarer

--- a/Resources/Prototypes/Entities/Structures/Furniture/sink.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/sink.yml
@@ -23,9 +23,9 @@
   - type: SolutionContainerManager
     solutions:
       drainBuffer:
-        maxVol: 100 # HardLight: Parity with Sink
-      tank:
         maxVol: 100
+      tank:
+        maxVol: 500
   - type: SolutionRegeneration
     solution: tank
     generated:
@@ -78,11 +78,11 @@
   - type: SolutionContainerManager
     solutions:
       drainBuffer:
-        maxVol: 100
+        maxVol: 200
       tank:
         reagents:
         - ReagentId: Water
-          Quantity: 100
+          Quantity: 500
 
 - type: entity
   name: wide sink
@@ -131,8 +131,8 @@
   - type: SolutionContainerManager
     solutions:
       drainBuffer:
-        maxVol: 100 # HardLight: Parity with Sink
+        maxVol: 100
       tank:
         reagents:
         - ReagentId: Water
-          Quantity: 100
+          Quantity: 500

--- a/Resources/Prototypes/Entities/Structures/Furniture/sink.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/sink.yml
@@ -82,7 +82,7 @@
       tank:
         reagents:
         - ReagentId: Water
-          Quantity: 500
+          Quantity: 250 # Wayfarer
 
 - type: entity
   name: wide sink

--- a/Resources/Prototypes/Entities/Structures/Furniture/sink.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/sink.yml
@@ -25,7 +25,7 @@
       drainBuffer:
         maxVol: 100
       tank:
-        maxVol: 500
+        maxVol: 250 # Wayfarer
   - type: SolutionRegeneration
     solution: tank
     generated:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removes the sink.yml volume changes that were made on https://github.com/project-wayfarer/wayfarer-14/pull/254
But retains all other changes.
Also removes some unnecessary comments given how some values are on pair with upstream.

Edit: Scratch that, we're making it 1 bucket volume I suppose.

## Why / Balance
The volume nerfs were rather... Unnecessary and were often solved by people building a lot of sinks. Not quite ideal.

## Technical details
yaml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/project-wayfarer/wayfarer-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](https://github.com/project-wayfarer/wayfarer-14/blob/master/AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Partly reverts sink volume changes, putting them closer to their original upstream values