### PR TITLE
feat(vore): disable vore verb if consent is disabled

### DIFF
--- a/Content.Server/FloofStation/VoreSystem.cs
+++ b/Content.Server/FloofStation/VoreSystem.cs
@@ -113,8 +113,16 @@ public sealed class VoreSystem : EntitySystem
 
     private void VoreVerb(EntityUid uid, VoreComponent component, GetVerbsEvent<InnateVerb> args)
     {
-        if (args.User != args.Target)
+        // Wayfarer: No vore verb if they turned consent off for vore (why was this missed?)
+        if (!args.CanInteract
+            || !args.CanAccess
+            || args.User != args.Target
+            || !HasComp<VoreComponent>(args.Target)
+            || !_consent.HasConsent(args.Target, "Vore")
+            || !_consent.HasConsent(args.User, "Vore")
+            || HasComp<VoredComponent>(args.User))
             return;
+        // End Warferer
 
         // Add toggle for showing examine text
         if (component.ShowOnExamine)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Disable vore verb if vore consent is disabled

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/project-wayfarer/wayfarer-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](https://github.com/project-wayfarer/wayfarer-14/blob/master/AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fix vore verb not being disabled when vore consent is disabled
