### PR TITLE
Mute ambient music when in range of an active midi/jukebox

### DIFF
--- a/Content.Client/Audio/ContentAudioSystem.AmbientMusic.cs
+++ b/Content.Client/Audio/ContentAudioSystem.AmbientMusic.cs
@@ -102,10 +102,8 @@ public sealed partial class ContentAudioSystem
     private bool _replayAmbientMusicBool;
 
     // Wayfarer
-    private const float ExternalMusicCheckInterval = 0.5f;
     private const float JukeboxAudibleRange = 10f; // matches JukeboxSystem WithMaxDistance
     private const float InstrumentAudibleRange = 15f;
-    private float _externalMusicCheckTimer;
     private bool _externallyMutedAmbient;
     // End Wayfarer
 
@@ -132,14 +130,7 @@ public sealed partial class ContentAudioSystem
         if (!_timing.IsFirstTimePredicted) //otherwise this will tick like 5x faster on client. thanks prediction
             return;
 
-        // Wayfarer
-        _externalMusicCheckTimer += frameTime;
-        if (_externalMusicCheckTimer >= ExternalMusicCheckInterval)
-        {
-            _externalMusicCheckTimer = 0f;
-            UpdateExternalMusicMute();
-        }
-        // End Wayfarer
+        UpdateExternalMusicMute(); // Wayfarer
 
         if (_initialStationMusicBool)
         {
@@ -590,27 +581,18 @@ public sealed partial class ContentAudioSystem
     // Wayfarer
     private void UpdateExternalMusicMute()
     {
-        if (_state.CurrentState is not GameplayState)
-            return;
-
         var localEnt = _player.LocalEntity;
         if (localEnt == null)
             return;
 
         var localXform = Transform(localEnt.Value);
-        if (localXform.MapID == MapId.Nullspace)
-            return;
-
         var localPos = _xform.GetWorldPosition(localXform);
         var audible = IsAnyExternalMusicAudible(localXform.MapID, localPos);
 
         if (audible)
         {
-            if (_ambientMusicStream != null)
-            {
-                _replayAmbientMusicBool = false;
-                DisableAmbientMusic();
-            }
+            _replayAmbientMusicBool = false;
+            DisableAmbientMusic();
             _externallyMutedAmbient = true;
         }
         else if (_externallyMutedAmbient)

--- a/Content.Client/Audio/ContentAudioSystem.AmbientMusic.cs
+++ b/Content.Client/Audio/ContentAudioSystem.AmbientMusic.cs
@@ -1,7 +1,10 @@
 using System.Linq;
+using System.Numerics; // Wayfarer
 using Content.Client.Gameplay;
+using Content.Client.Instruments; // Wayfarer
 using Content.Shared._Crescent.SpaceBiomes;
 using Content.Shared.Audio;
+using Content.Shared.Audio.Jukebox; // Wayfarer
 using Content.Shared.CCVar;
 using Content.Shared.GameTicking;
 using Content.Client._Crescent.SpaceBiomes;
@@ -10,6 +13,7 @@ using Robust.Client.State;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
+using Robust.Shared.Map; // Wayfarer
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -38,6 +42,7 @@ public sealed partial class ContentAudioSystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly CombatModeSystem _combatModeSystem = default!; //CLIENT ONE. WHY ARE THERE 3??
     [Dependency] private readonly SpaceBiomeSystem _spaceBiome = default!;
+    [Dependency] private readonly SharedTransformSystem _xform = default!; // Wayfarer
 
     //options menu ---
     private static float _volumeSliderAmbient;
@@ -95,6 +100,15 @@ public sealed partial class ContentAudioSystem
 
     private float _replayAmbientMusicTimer = 0;
     private bool _replayAmbientMusicBool;
+
+    // Wayfarer
+    private const float ExternalMusicCheckInterval = 0.5f;
+    private const float JukeboxAudibleRange = 10f; // matches JukeboxSystem WithMaxDistance
+    private const float InstrumentAudibleRange = 15f;
+    private float _externalMusicCheckTimer;
+    private bool _externallyMutedAmbient;
+    // End Wayfarer
+
     private float _combatWindUpTimer = 0;
     private bool _combatWindUpBool = false;
     private float _combatWindDownTimer = 0;
@@ -117,6 +131,15 @@ public sealed partial class ContentAudioSystem
 
         if (!_timing.IsFirstTimePredicted) //otherwise this will tick like 5x faster on client. thanks prediction
             return;
+
+        // Wayfarer
+        _externalMusicCheckTimer += frameTime;
+        if (_externalMusicCheckTimer >= ExternalMusicCheckInterval)
+        {
+            _externalMusicCheckTimer = 0f;
+            UpdateExternalMusicMute();
+        }
+        // End Wayfarer
 
         if (_initialStationMusicBool)
         {
@@ -564,4 +587,64 @@ public sealed partial class ContentAudioSystem
         _ambientMusicStream = null;
     }
 
+    // Wayfarer
+    private void UpdateExternalMusicMute()
+    {
+        if (_state.CurrentState is not GameplayState)
+            return;
+
+        var localEnt = _player.LocalEntity;
+        if (localEnt == null)
+            return;
+
+        var localXform = Transform(localEnt.Value);
+        if (localXform.MapID == MapId.Nullspace)
+            return;
+
+        var localPos = _xform.GetWorldPosition(localXform);
+        var audible = IsAnyExternalMusicAudible(localXform.MapID, localPos);
+
+        if (audible)
+        {
+            if (_ambientMusicStream != null)
+            {
+                _replayAmbientMusicBool = false;
+                DisableAmbientMusic();
+            }
+            _externallyMutedAmbient = true;
+        }
+        else if (_externallyMutedAmbient)
+        {
+            _externallyMutedAmbient = false;
+            ReplayAmbientMusic();
+        }
+    }
+
+    private bool IsAnyExternalMusicAudible(MapId localMap, Vector2 localPos)
+    {
+        var jukeQuery = AllEntityQuery<JukeboxComponent, TransformComponent>();
+        while (jukeQuery.MoveNext(out _, out var jukebox, out var xform))
+        {
+            if (jukebox.AudioStream == null)
+                continue;
+            if (xform.MapID != localMap)
+                continue;
+            if (Vector2.Distance(_xform.GetWorldPosition(xform), localPos) <= JukeboxAudibleRange)
+                return true;
+        }
+
+        var instQuery = AllEntityQuery<InstrumentComponent, TransformComponent>();
+        while (instQuery.MoveNext(out _, out var instrument, out var xform))
+        {
+            if (!instrument.Playing)
+                continue;
+            if (xform.MapID != localMap)
+                continue;
+            if (Vector2.Distance(_xform.GetWorldPosition(xform), localPos) <= InstrumentAudibleRange)
+                return true;
+        }
+
+        return false;
+    }
+    // End Wayfarer
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Ambient music will mute automatically when player is in range of an active jukebox or instrument.

**Disclosure:** This code was made with the assistance of AI.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I would consider it a convenience feature, many players dislike overlapping audio.

## Technical details
<!-- Summary of code changes for easier review. -->
Edits to Content.Client/Audio/ContentAudioSystem.AmbientMusic.cs
- Every frame, the ambient music system checks for any nearby jukebox (within 10 tiles) or playing MIDI instrument (within 15 tiles) on the same map.
- If either is in range, ambient music is faded out and auto-replay is paused.
- Once out of range, ambient music plays again.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Move back and forth between instruments and jukeboxes to hear the ambient music fade in and out.


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: (Miles) Ambient music mutes when in range of an active jukebox or instrument.