### PR TITLE
fix: Set default value for DampingModifier in ShuttleComponent

### DIFF
--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -67,7 +67,7 @@ namespace Content.Server.Shuttles.Components
         /// Damping modifier applied to the shuttle's physics component.
         /// </summary>
         [DataField]
-        public float DampingModifier;
+        public float DampingModifier = 0.25f;
         // Wayfarer end
 
         /// <summary>

--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -67,7 +67,7 @@ namespace Content.Server.Shuttles.Components
         /// Damping modifier applied to the shuttle's physics component.
         /// </summary>
         [DataField]
-        public float DampingModifier = 0.25f;
+        public float DampingModifier = 0.25f; // Wayfarer: 0<0.25
         // Wayfarer end
 
         /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes weird zero friction issue. Which players inherit(???)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
PR #297 removed the old BodyModifier = 0.25f field and the OnShuttleStartup line component.DampingModifier = component.BodyModifier, but left DampingModifier without a default value. so it defaulted to 0f.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- fix: Fixed weird 0 friction in space
