### PR TITLE
Two fitting blip colors (Most difficult PR ever)

### DIFF
--- a/Content.Shared/_CS/BlipCartridge/BlipCartridgeComponent.cs
+++ b/Content.Shared/_CS/BlipCartridge/BlipCartridgeComponent.cs
@@ -69,6 +69,8 @@ public sealed partial class BlipCartridgeComponent : Component
         "BlipColorBlue",
         "BlipColorCyan",
         "BlipColorTeal",
+        "BlipColorEnigmatic", // Wayfarer
+        "BlipColorSilver", // Wayfarer
     };
 
     /// <summary>

--- a/Resources/Prototypes/_CS/Blipz/blip_color_set.yml
+++ b/Resources/Prototypes/_CS/Blipz/blip_color_set.yml
@@ -103,5 +103,18 @@
   color: gray
   highlightedColor: lightgray
 
+# Wayfarer
+- type: blipColorSet
+  id: BlipColorEnigmatic
+  name: Enigmatic Orchid
+  order: 16
+  color: darkorchid
+  highlightedColor: darkorchid
 
-
+- type: blipColorSet
+  id: BlipColorSilver
+  name: Quicksilver
+  order: 16
+  color: Silver
+  highlightedColor: silver
+# End Wayfarer


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds two new blip colors.
Enigmatic Orchid & Quicksilver
This does not expand the menu enough to make it need a scroll. Fits perfect.

## Why / Balance
Colors of this nature were missing. Not annoying choices.

## Technical details
Yaml C#

## How to test
Change your blip and make it big!

## Media
<img width="614" height="411" alt="image" src="https://github.com/user-attachments/assets/3c4c8929-153d-4b28-ac2a-a54bbfcd7b1f" />
<img width="563" height="463" alt="image" src="https://github.com/user-attachments/assets/3da059f6-ac54-47d2-80b1-d5c3a99df062" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Added Colors for blips! (Really simple.)
