### PR TITLE
Adds new chatwindow shortcut

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChatInputBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChatInputBox.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Client.Stylesheets;
+using Content.Client.UserInterface.Systems.Chat;
 using Content.Shared.Chat;
 using Content.Shared.Input;
 using Robust.Client.UserInterface.Controls;
@@ -44,6 +45,19 @@ public class ChatInputBox : PanelContainer
             Name = "FilterButton",
             StyleClasses = {"chatFilterOptionButton"}
         };
+        var newWindowButton = new Button
+        {
+            Name = "NewWindowButton",
+            Text = "+",
+            MinWidth = 24,
+            ToolTip = "Open new chat window"
+        };
+        newWindowButton.OnPressed += _ =>
+        {
+            var window = new ChatWindow();
+            window.OpenCentered();
+        };
+        Container.AddChild(newWindowButton);
         Container.AddChild(FilterButton);
         AddStyleClass(StyleNano.StyleClassChatSubPanel);
         ChannelSelector.OnChannelSelect += UpdateActiveChannel;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a + button next to filter that is a shortcut to open a new chat window. useful for creating a new window with specific filters.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<img width="783" height="794" alt="image" src="https://github.com/user-attachments/assets/f412893d-a8a5-4711-82f4-3bd26443d83d" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [ ] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [ ] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- add: Added "New Chat" popout shortcut button