### PR TITLE
Removal of Edisons Sugar Daddy

### DIFF
--- a/Content.Shared/SmartFridge/SmartFridgeComponent.cs
+++ b/Content.Shared/SmartFridge/SmartFridgeComponent.cs
@@ -79,7 +79,7 @@ public sealed partial class SmartFridgeComponent : Component
     /// The maximum number of entities that can be stored in the fridge
     /// </summary>
     [DataField]
-    public int MaxContainedCount = 300;
+    public int MaxContainedCount = 3000; //Wayfarer x10 increase 300-> 3000
 
     /// <summary>
     /// If true, insertion requires access

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -116,6 +116,7 @@
     taxAccounts:
       Frontier: 0.25
       Nfsd: 0.15
+      Medical: 0.10 # Wayfarer just a small bit towards medical
     cashSlot:
       whitelist:
         components:

--- a/Resources/Prototypes/_NF/Entities/Clothing/Neck/badges.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Neck/badges.yml
@@ -23,7 +23,7 @@
   parent: ClothingNeckNfsdBadge
   id: ClothingNeckNfsdBadgeSecurity
   suffix: Silver - Peacekeeper
-  name: CGP junior peacekeeper badge
+  name: CGP peacekeeper badge
   components:
   - type: Sprite
     sprite: _NF/Clothing/Neck/Scarfs/nfsd_silver_badge.rsi

--- a/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
@@ -85,7 +85,7 @@
       Nfsd: 0.25
       Frontier: 0.25
       Medical: 0.25
-      Edison: 0.25
+    #  Edison: 0.25 Wayfayer: Edison should make it's own money.
 
 - type: entity
   id: BluespaceVaultSmallError
@@ -131,7 +131,7 @@
       Nfsd: 0.25
       Frontier: 0.25
       Medical: 0.25
-      Edison: 0.25
+    #  Edison: 0.25 Wayfayer: Edison should make it's own money.
 
 - type: entity
   id: BluespaceSyndicateFTLInterception


### PR DESCRIPTION
## Technical details
Removes Edison from guard rewards from vaults
Added medical to get a small portion of most vendor sales.
Smart fridges have 10x capacity

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Taxes to vendors that give to medical
- remove: Edison no longer gets vault rewards
- tweak: Smartfridges has 10x capacity 
- tweak: CGP badge renaming to be correct


