### PR TITLE
Interact verb improvements

### DIFF
--- a/Content.Server/InteractionVerbs/Actions/ForceDownAction.cs
+++ b/Content.Server/InteractionVerbs/Actions/ForceDownAction.cs
@@ -1,0 +1,28 @@
+using Content.Shared.InteractionVerbs;
+using Content.Shared.Standing;
+using Content.Shared.Stunnable;
+
+namespace Content.Server.InteractionVerbs.Actions;
+
+/// <summary>
+///     Forces the target entity prone (knocked down) until they manually stand back up.
+/// </summary>
+[Serializable]
+public sealed partial class ForceDownAction : InteractionAction
+{
+    public override bool CanPerform(InteractionArgs args, InteractionVerbPrototype proto, bool isBefore, VerbDependencies deps)
+    {
+        if (isBefore)
+            return true;
+
+        // Don't apply if the target is already knocked down.
+        var standing = deps.EntityManager.System<StandingStateSystem>();
+        return !standing.IsDown(args.Target);
+    }
+
+    public override bool Perform(InteractionArgs args, InteractionVerbPrototype proto, VerbDependencies deps)
+    {
+        var stunSystem = deps.EntityManager.System<SharedStunSystem>();
+        return stunSystem.TryKnockdown(args.Target, time: null, refresh: true, autoStand: false, drop: true, force: true);
+    }
+}

--- a/Content.Server/InteractionVerbs/InteractionVerbsSystem.cs
+++ b/Content.Server/InteractionVerbs/InteractionVerbsSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.ActionBlocker;
 using Content.Shared.Chat;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.InteractionVerbs;
 using Content.Shared.Popups;
@@ -81,6 +82,10 @@ public sealed class InteractionVerbsSystem : SharedInteractionVerbsSystem
         if (effect.Popup != null && PrototypeManager.TryIndex(effect.Popup.Value, out var popupProto))
         {
             var hasUsed = args.Used != null;
+            // Use identity entities for public-facing messages so hidden IDs are respected.
+            var identityUser = Identity.Entity(args.User, EntityManager);
+            var identityTarget = Identity.Entity(args.Target, EntityManager);
+
             var selfMessage = Loc.GetString($"interaction-{proto.ID}-{prefix.ToString().ToLower()}-{popupProto.SelfSuffix}-popup",
                 ("user", args.User),
                 ("target", args.Target),
@@ -90,7 +95,7 @@ public sealed class InteractionVerbsSystem : SharedInteractionVerbsSystem
 
             var targetMessage = popupProto.TargetSuffix != null
                 ? Loc.GetString($"interaction-{proto.ID}-{prefix.ToString().ToLower()}-{popupProto.TargetSuffix}-popup",
-                    ("user", args.User),
+                    ("user", identityUser),
                     ("target", args.Target),
                     ("used", args.Used ?? EntityUid.Invalid),
                     ("selfTarget", args.User == args.Target),
@@ -99,8 +104,8 @@ public sealed class InteractionVerbsSystem : SharedInteractionVerbsSystem
 
             var othersMessage = popupProto.OthersSuffix != null
                 ? Loc.GetString($"interaction-{proto.ID}-{prefix.ToString().ToLower()}-{popupProto.OthersSuffix}-popup",
-                    ("user", args.User),
-                    ("target", args.Target),
+                    ("user", identityUser),
+                    ("target", identityTarget),
                     ("used", args.Used ?? EntityUid.Invalid),
                     ("selfTarget", args.User == args.Target),
                     ("hasUsed", hasUsed))
@@ -127,8 +132,8 @@ public sealed class InteractionVerbsSystem : SharedInteractionVerbsSystem
             if (popupProto.EmoteSuffix != null)
             {
                 var chatMessage = Loc.GetString($"interaction-{proto.ID}-{prefix.ToString().ToLower()}-{popupProto.EmoteSuffix}-popup",
-                    ("user", args.User),
-                    ("target", args.Target),
+                    ("user", identityUser),
+                    ("target", identityTarget),
                     ("used", args.Used ?? EntityUid.Invalid),
                     ("selfTarget", args.User == args.Target),
                     ("hasUsed", hasUsed));

--- a/Content.Server/InteractionVerbs/InteractionVerbsSystem.cs
+++ b/Content.Server/InteractionVerbs/InteractionVerbsSystem.cs
@@ -182,7 +182,7 @@ public sealed class InteractionVerbsSystem : SharedInteractionVerbsSystem
                 : null;
 
             // Show popup to user
-            _popupSystem.PopupEntity(selfMessage, args.Target, args.User, PopupType.Medium);
+            // _popupSystem.PopupEntity(selfMessage, args.Target, args.User, PopupType.Medium);
 
             // Show popup to target if different from user
             if (args.User != args.Target && targetMessage != null)

--- a/Content.Server/InteractionVerbs/InteractionVerbsSystem.cs
+++ b/Content.Server/InteractionVerbs/InteractionVerbsSystem.cs
@@ -2,11 +2,14 @@ using Content.Server.Chat.Managers;
 using Content.Server.Chat.Systems;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Chat;
+using Content.Shared.DoAfter;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.InteractionVerbs;
+using Content.Shared.InteractionVerbs.Events;
+using Content.Shared.Mobs.Components;
 using Content.Shared.Popups;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
@@ -23,10 +26,58 @@ public sealed class InteractionVerbsSystem : SharedInteractionVerbsSystem
     [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
     [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
     [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
 
     public override void Initialize()
     {
         base.Initialize();
+        // DoAfter events are DIRECTED events (raised on eventTarget), so we must use the component-based
+        // subscription. eventTarget is always the user, who always has MobStateComponent.
+        SubscribeLocalEvent<MobStateComponent, InteractionVerbDoAfterEvent>(OnInteractionVerbDoAfter);
+    }
+
+    private void OnInteractionVerbDoAfter(EntityUid uid, MobStateComponent _, InteractionVerbDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled)
+            return;
+
+        if (!PrototypeManager.TryIndex(args.VerbPrototype, out InteractionVerbPrototype? verbProto))
+            return;
+
+        var user = uid; // uid == eventTarget == user
+        var target = GetEntity(args.Target);
+
+        if (!user.IsValid() || !target.IsValid())
+            return;
+
+        var hasHands = HasComp<HandsComponent>(user);
+        var canAccess = _interactionSystem.InRangeUnobstructed(user, target);
+        var canInteract = _actionBlockerSystem.CanInteract(user, target);
+
+        EntityUid? usedItem = null;
+        if (hasHands)
+            usedItem = _handsSystem.GetActiveItem(user);
+
+        var interactionArgs = new InteractionArgs(user, target, usedItem, canAccess, canInteract, hasHands, null);
+
+        if (verbProto.Action != null && !verbProto.Action.CanPerform(interactionArgs, verbProto, false, _verbDependencies))
+        {
+            if (verbProto.EffectFailure != null)
+                ShowEffects(verbProto, verbProto.EffectFailure, InteractionPopupPrototype.Prefix.Fail, interactionArgs);
+            return;
+        }
+
+        bool success = verbProto.Action?.Perform(interactionArgs, verbProto, _verbDependencies) ?? true;
+
+        if (success && verbProto.EffectSuccess != null)
+            ShowEffects(verbProto, verbProto.EffectSuccess, InteractionPopupPrototype.Prefix.Success, interactionArgs);
+        else if (!success && verbProto.EffectFailure != null)
+            ShowEffects(verbProto, verbProto.EffectFailure, InteractionPopupPrototype.Prefix.Fail, interactionArgs);
+
+        if (success && verbProto.DoContactInteraction)
+            _interactionSystem.DoContactInteraction(user, target);
+
+        args.Handled = true;
     }
 
     protected override void TryPerformVerb(InteractionVerbPrototype proto, EntityUid user, EntityUid target)
@@ -57,7 +108,26 @@ public sealed class InteractionVerbsSystem : SharedInteractionVerbsSystem
                 return;
         }
 
-        // Perform the action
+        // If there's a delay, start a do-after and defer the rest
+        if (verbProto.Delay > TimeSpan.Zero)
+        {
+            var doAfterArgs = new DoAfterArgs(
+                EntityManager,
+                user,
+                verbProto.Delay,
+                new InteractionVerbDoAfterEvent(GetNetEntity(target), verbProto.ID),
+                eventTarget: user,
+                target: target)
+            {
+                BreakOnMove = true,
+                BreakOnDamage = true,
+                NeedHand = verbProto.RequiresHands,
+            };
+            _doAfterSystem.TryStartDoAfter(doAfterArgs);
+            return;
+        }
+
+        // Perform the action immediately (no delay)
         bool success = verbProto.Action?.Perform(args, verbProto, _verbDependencies) ?? true;
 
         // Show effects

--- a/Resources/Locale/en-US/interaction/verbs.ftl
+++ b/Resources/Locale/en-US/interaction/verbs.ftl
@@ -69,3 +69,11 @@ interaction-LookAt-success-self-popup = You look at {THE($target)}.
 interaction-LookAt-success-target-popup = {THE($user)} looks at you.
 interaction-LookAt-success-others-popup = {THE($user)} looks at {THE($target)}.
 interaction-LookAt-success-emote-popup = looks at {THE($target)}.
+
+# Force Down Interaction
+interaction-ForceDown-name = Force down
+interaction-ForceDown-description = Force someone to the ground.
+interaction-ForceDown-success-self-popup = You force {THE($target)} to the ground!
+interaction-ForceDown-success-target-popup = {THE($user)} forces you to the ground!
+interaction-ForceDown-success-others-popup = {THE($user)} forces {THE($target)} to the ground!
+interaction-ForceDown-success-emote-popup = forces {THE($target)} to the ground!

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -183,6 +183,7 @@
     - Hug
     - Pet
     - LookAt
+    - ForceDown
   - type: CanHostGuardian
   - type: NpcFactionMember
     factions:

--- a/Resources/Prototypes/InteractionVerbs/example_entities.yml
+++ b/Resources/Prototypes/InteractionVerbs/example_entities.yml
@@ -35,6 +35,7 @@
     - Hug
     - Pet
     - LookAt
+    - ForceDown
   - type: Sprite
     sprite: Mobs/Species/Human/parts.rsi
     state: full

--- a/Resources/Prototypes/InteractionVerbs/interaction_verbs.yml
+++ b/Resources/Prototypes/InteractionVerbs/interaction_verbs.yml
@@ -170,3 +170,28 @@
   priority: 0
   categoryKey: interaction
   global: true  # Allow looking at any entity, not just mobs
+
+# Force Down Interaction
+- type: Interaction
+  id: ForceDown
+  action:
+    !type:ForceDownAction
+  effectSuccess:
+    popup: DefaultInteraction
+    effectTarget: TargetThenUser
+    soundPerceivedByOthers: true
+    sound:
+      path: /Audio/Effects/thudswoosh.ogg
+      params:
+        volume: -3
+        variation: 0.15
+  delay: 2
+  cooldown: 5
+  range:
+    min: 0
+    max: 1.5
+  requiresCanInteract: true
+  requiresHands: true
+  allowSelfInteract: false
+  priority: 0
+  categoryKey: interaction

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -302,6 +302,7 @@
       - Hug
       - Pet
       - LookAt
+      - ForceDown
 
 - type: damageModifierSet
   id: IPC


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Added identity management so if an ID is hidden, InteractVerbs wont spoil the secret
- Added "Force Down" verb
- Commented out Self Verb Popup

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [ ] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- add: Added "Force down" emote verb
- tweak: Changed emote verbs to respect identity system if someones ID is hidden
