### PR TITLE
fix(avali): stomach properly

### DIFF
--- a/Resources/Prototypes/_Starlight/Body/Organs/avali.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/avali.yml
@@ -5,7 +5,6 @@
   name: stomach
   description: "The stomach of an avali, on closer inspection, actually consists of two stomachs."
   components:
-  - type: Stomach
     # Wayfarer: Removed specialDigestible
   - type: SolutionContainerManager
     solutions:

--- a/Resources/Prototypes/_Starlight/Body/Organs/avali.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/avali.yml
@@ -6,13 +6,7 @@
   description: "The stomach of an avali, on closer inspection, actually consists of two stomachs."
   components:
   - type: Stomach
-    specialDigestible:
-      tags:
-      - Meat
-      - Pill
-      - Crayon
-      - Paper
-      - AvianFood
+    # Wayfarer: Removed specialDigestible
   - type: SolutionContainerManager
     solutions:
       stomach:

--- a/Resources/Prototypes/_Starlight/Body/Prototypes/avali.yml
+++ b/Resources/Prototypes/_Starlight/Body/Prototypes/avali.yml
@@ -22,7 +22,7 @@
       organs:
         heart: OrganAvaliHeart
         lungs: OrganAvaliLungs
-        stomach: OrganHumanStomach
+        stomach: OrganAvaliStomach
         liver: OrganAvaliLiver
         kidneys: OrganAvaliKidneys
         # Wayfarer - null organ doesn't work

--- a/Resources/Prototypes/_Starlight/Body/Prototypes/avali.yml
+++ b/Resources/Prototypes/_Starlight/Body/Prototypes/avali.yml
@@ -22,7 +22,7 @@
       organs:
         heart: OrganAvaliHeart
         lungs: OrganAvaliLungs
-        stomach: OrganHumanStomach #Wayfarer - changed to human stomach OrganAvaliStomach->OrganHumanStomach
+        stomach: OrganHumanStomach
         liver: OrganAvaliLiver
         kidneys: OrganAvaliKidneys
         # Wayfarer - null organ doesn't work

--- a/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Avali.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Avali.xml
@@ -15,7 +15,6 @@
   - Can stand in tempatures of up to [color=#1e90ff]-50c before taking cold damage[/color].
   - Deal [color=red]6.25[/color] slashing damage with claws.
   - Can fly in Zero-G.
-  - Can only eat meat-related food items (including organs) and pills.
   - Heal airloss from Ammonia and Amoxla but..
   - Saline will burn you, and both Dexalin and Dexalin+ are lethal to you. Remember to remind doctors about it!
   - Fall into crit at 90 and dead at 180.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Properly make it so avali stomach can digest all food while being avali's stomach

Fix #747

## Why / Balance
Old fix relies on switching from Avali stomach to Human stomach, this PR make it so Avali stomach can digest all type of food

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
