### PR TITLE
Partially reverts a Frontier nerf to Vox trash reagent processing & Vox stacks update #1

### DIFF
--- a/Resources/Prototypes/Body/Organs/vox.yml
+++ b/Resources/Prototypes/Body/Organs/vox.yml
@@ -100,11 +100,26 @@
 
 - type: entity
   parent: OrganHumanBrain
-  id: OrganVoxStack
+  id: OrganVoxStack # Wayfarer
   name: cortical stack
-  description: "A stack containing all the memories and experiences of a vox."
+  description: "A advanced bio-electronic device containing all the memories and identity of a Vox."
   components:
   - type: Sprite
     sprite: Mobs/Species/Vox/organs.rsi
   - type: Item
     size: Small
+  - type: SolutionContainerManager
+    solutions:
+      organ:
+        reagents:
+        - ReagentId: Silicon
+          Quantity: 10
+        - ReagentId: GreyMatter
+          Quantity: 5
+      food:
+        maxVol: 15
+        reagents:
+        - ReagentId: Silicon
+          Quantity: 10
+        - ReagentId: GreyMatter
+          Quantity: 5

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -744,7 +744,7 @@
     Food:
       effects:
       - !type:SatiateHunger
-        factor: 0.2 # Frontier: 1<0.2
+        factor: 0.8 # Frontier: 1<0.2 # Wayfarer: 0.2<0.8
         conditions:
         - !type:OrganType
           type: Vox


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds proper reagents to Vox Cortical Stacks in line with the brains of other species. Fixed description as well.
Adjusts trash reagent rates to be actually worth considering but not enough to be anywhere near or as good as eating real food.

## Why / Balance
Brings things in line with other brains.
Makes a species quirk not useless

## Technical details
yaml

## How to test
Boot up, eat trash, grind or eat a stack. (please don't (again))

## Media
<img width="1053" height="549" alt="image" src="https://github.com/user-attachments/assets/15a29ff1-d388-4e40-8308-e2fdded2be35" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Proper reagents to Vox brains.
- tweak: Changed trash reagent values for Vox! Gimmie the gorbage.