### PR TITLE
Made respiron better so avalis don't choke out

### DIFF
--- a/Resources/Prototypes/_NF/Reagents/gases.yml
+++ b/Resources/Prototypes/_NF/Reagents/gases.yml
@@ -9,11 +9,11 @@
     Poison:
       effects:
       - !type:Oxygenate
-        factor: 1.75 #Wayfarer: Buffed oxygenation rate
+        factor: 1.5 #Wayfarer: Buffed oxygenation rate
     Gas:
       effects:
       - !type:Oxygenate
-        factor: 1.75 #Wayfarer: Buffed oxygenation rate
+        factor: 1.5 #Wayfarer: Buffed oxygenation rate
       - !type:ModifyLungGas
         conditions:
         - !type:OrganType

--- a/Resources/Prototypes/_NF/Reagents/gases.yml
+++ b/Resources/Prototypes/_NF/Reagents/gases.yml
@@ -9,11 +9,11 @@
     Poison:
       effects:
       - !type:Oxygenate
-        factor: 1.25
+        factor: 1.75 #Wayfarer: Buffed oxygenation rate
     Gas:
       effects:
       - !type:Oxygenate
-        factor: 1.25
+        factor: 1.75 #Wayfarer: Buffed oxygenation rate
       - !type:ModifyLungGas
         conditions:
         - !type:OrganType


### PR DESCRIPTION
## About the PR
Increases the oxygenation rate of respiron to 1.5.

## Why / Balance
Helps species like avalis and harpies choke less. Respiron only atmospheres tolerate a slower kpa (you can be comfortable at around 35kpa now).
People were reporting choking a lot with respiron, needing an absurd amount of pressure to allow breathing.

## Technical details
Changed _NF gas reagents file, added a small comment at the side of it
## How to test
spawn harpy
put in box
box to 35 kpa
no gasp
good


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- add: Buffed respiron oxygenation rate.
