### PR TITLE
Lathe (and ore processor) craft-maximum

### DIFF
--- a/Content.Client/Lathe/UI/LatheMenu.xaml.cs
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml.cs
@@ -146,7 +146,7 @@ public sealed partial class LatheMenu : DefaultWindow
                 if (!int.TryParse(AmountLineEdit.Text, out var amount) || amount <= 0)
                     amount = 1;
 
-                if (AmountLineEdit.Text.ToLower() == "max") // Wayfarer
+                if (AmountLineEdit.Text.ToLower() == "max" || AmountLineEdit.Text.ToLower() == "all") // Wayfarer: Allow crafting a recipe the maximum number of times
                     amount = GetMaximumCraftQuantity(prototype);
 
                 RecipeQueueAction?.Invoke(s, amount);

--- a/Content.Client/Lathe/UI/LatheMenu.xaml.cs
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml.cs
@@ -145,6 +145,10 @@ public sealed partial class LatheMenu : DefaultWindow
             {
                 if (!int.TryParse(AmountLineEdit.Text, out var amount) || amount <= 0)
                     amount = 1;
+
+                if (AmountLineEdit.Text.ToLower() == "max") // Wayfarer
+                    amount = GetMaximumCraftQuantity(prototype);
+
                 RecipeQueueAction?.Invoke(s, amount);
             };
             RecipeList.AddChild(control);

--- a/Content.Client/_CS/Lathe/UI/LatheMenu.xaml.cs
+++ b/Content.Client/_CS/Lathe/UI/LatheMenu.xaml.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Content.Shared.Lathe;
 using Content.Shared.Research.Prototypes;
 
@@ -49,25 +48,6 @@ public sealed partial class LatheMenu
         }
         return true;
     }
-
-    private int GetMaximumCraftQuantity(LatheRecipePrototype recipe) // Wayfarer
-    {
-        if (!_entityManager.TryGetComponent(Entity, out LatheComponent? lathe))
-            return 1;
-
-        var maxPerMaterial = new List<int>();
-
-        foreach (var (material, amount) in recipe.Materials)
-        {
-            var cost = SharedLatheSystem.AdjustMaterial(amount,
-                recipe.ApplyMaterialDiscount,
-                lathe.FinalMaterialUseMultiplier);
-            maxPerMaterial.Add(GetTotalMaterialAmount(material, _bufferAmount ?? 0) / cost);
-        }
-
-        return maxPerMaterial.Min();
-    }
-
     /// <summary>
     /// Gets the total available amount of a material, including buffer contributions for biomass.
     /// </summary>

--- a/Content.Client/_CS/Lathe/UI/LatheMenu.xaml.cs
+++ b/Content.Client/_CS/Lathe/UI/LatheMenu.xaml.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Shared.Lathe;
 using Content.Shared.Research.Prototypes;
 
@@ -48,6 +49,25 @@ public sealed partial class LatheMenu
         }
         return true;
     }
+
+    private int GetMaximumCraftQuantity(LatheRecipePrototype recipe) // Wayfarer
+    {
+        if (!_entityManager.TryGetComponent(Entity, out LatheComponent? lathe))
+            return 1;
+
+        var maxPerMaterial = new List<int>();
+
+        foreach (var (material, amount) in recipe.Materials)
+        {
+            var cost = SharedLatheSystem.AdjustMaterial(amount,
+                recipe.ApplyMaterialDiscount,
+                lathe.FinalMaterialUseMultiplier);
+            maxPerMaterial.Add(GetTotalMaterialAmount(material, _bufferAmount ?? 0) / cost);
+        }
+
+        return maxPerMaterial.Min();
+    }
+
     /// <summary>
     /// Gets the total available amount of a material, including buffer contributions for biomass.
     /// </summary>

--- a/Content.Client/_WF/Lathe/UI/LatheMenu.xaml.cs
+++ b/Content.Client/_WF/Lathe/UI/LatheMenu.xaml.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using Content.Shared.Lathe;
+using Content.Shared.Research.Prototypes;
+
+namespace Content.Client.Lathe.UI;
+
+public sealed partial class LatheMenu
+{
+    /// <summary>
+    /// Returns the maximum number of times a given recipe can be crafted.
+    /// Useful for crafting as many of something as possible
+    /// </summary>
+    /// <param name="recipe"></param> The recipe to check crafting limit for
+    /// <returns></returns> An integer representing the maximum number of times the recipe can be crafted
+    private int GetMaximumCraftQuantity(LatheRecipePrototype recipe) // Wayfarer
+    {
+        if (!_entityManager.TryGetComponent(Entity, out LatheComponent? lathe))
+            return 1;
+
+        var maxPerMaterial = new List<int>();
+
+        foreach (var (material, amount) in recipe.Materials)
+        {
+            var cost = SharedLatheSystem.AdjustMaterial(amount,
+                recipe.ApplyMaterialDiscount,
+                lathe.FinalMaterialUseMultiplier);
+            maxPerMaterial.Add(GetTotalMaterialAmount(material, _bufferAmount ?? 0) / cost);
+        }
+
+        return maxPerMaterial.Min();
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Adds new helper function to the lathe UI code that finds the max # of times a particular recipe can be crafted
- "max" or "all" can entered into the quantity text input to craft the maximum number of items

## Why / Balance
Addresses [project-wayfarer/wayfarer-14/issues/675]

## Technical details
- Adds `GetMaximumCraftQuantity` in `Content.Client.Lathe.UI`, which takes a `LatheRecipePrototype` and returns the maximum number of times the recipe can be crafted given the lathe's contents
- `Content.Client.Lathe.UI.LatheMenu` now accepts "max" or "all" as quantities. Case insensitive

## How to test
- Build/run
- Open a lathe's UI, ensuring it has the materials to craft a few repeats of the same recipe
- Enter `max` or `all` into the text field for crafting quantity (case insensitive)
- Click a recipe
- Expected result: Multiple crafts of the same item are queued, and no additional crafting can be requested due to resource constraints.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: 
- tweak: The crafting quantity on lathe UIs can now be set to 'max' or 'all' (case insensitive) to allow spending all of your precious resources on that one thing you need 1000 of. (This applies to ore processors, too)