### PR TITLE
Add WFClayBody Quirk

### DIFF
--- a/Content.Server/_CS/Body/Systems/SizeManipulationSystem.cs
+++ b/Content.Server/_CS/Body/Systems/SizeManipulationSystem.cs
@@ -57,6 +57,43 @@ public sealed class SizeManipulationSystem : EntitySystem
     }
 
     /// <summary>
+    /// Applies a size change to the target entity, bypassing the consent check.
+    /// Intended for trait-driven mechanics like Clay Body where consent does not apply.
+    /// </summary>
+    public bool TryChangeSizeForced(EntityUid target, SizeManipulatorMode mode, EntityUid? user = null)
+    {
+        if (!HasComp<MobStateComponent>(target))
+            return false;
+
+        var sizeComp = EnsureComp<SizeAffectedComponent>(target);
+
+        float newScale;
+        if (mode == SizeManipulatorMode.Grow)
+        {
+            newScale = sizeComp.ScaleMultiplier + sizeComp.ScaleChangeAmount;
+            if (newScale > sizeComp.MaxScale)
+                return false;
+        }
+        else
+        {
+            newScale = sizeComp.ScaleMultiplier - sizeComp.ScaleChangeAmount;
+            if (newScale < sizeComp.MinScale)
+                return false;
+        }
+
+        sizeComp.ScaleMultiplier = newScale;
+        Dirty(target, sizeComp);
+        ApplyPhysicsScale(target, newScale, sizeComp.BaseScale);
+
+        var message = mode == SizeManipulatorMode.Grow
+            ? Loc.GetString("size-manipulator-target-grow")
+            : Loc.GetString("size-manipulator-target-shrink");
+        _popup.PopupEntity(message, target, PopupType.Medium);
+
+        return true;
+    }
+
+    /// <summary>
     /// Applies a size change to the target entity
     /// </summary>
     public bool TryChangeSize(EntityUid target, SizeManipulatorMode mode, EntityUid? user = null, bool safetyDisabled = false)

--- a/Content.Server/_WF/Traits/ClayBodySystem.cs
+++ b/Content.Server/_WF/Traits/ClayBodySystem.cs
@@ -1,0 +1,191 @@
+using Content.Server._CS.Body.Systems;
+using Content.Server.Chat.Managers;
+using Content.Shared._CS.Body.Components;
+using Content.Shared._CS.Weapons.Ranged.Components;
+using Content.Shared._WF.Traits;
+using Content.Shared.Chat;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Interaction;
+using Content.Shared.Popups;
+using Content.Shared.Verbs;
+using Robust.Server.GameObjects;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+
+namespace Content.Server._WF.Traits;
+
+public sealed class ClayBodySystem : EntitySystem
+{
+    [Dependency] private readonly SizeManipulationSystem _sizeManip = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IChatManager _chatManager = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<WFClayBodyComponent, GetVerbsEvent<AlternativeVerb>>(OnGetAlternativeVerbs);
+        SubscribeLocalEvent<WFClayBodyComponent, InteractUsingEvent>(OnInteractUsing);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<WFClayBodyComponent>();
+        while (query.MoveNext(out var uid, out var clay))
+        {
+            if (clay.NextRegenTime == null)
+                continue;
+
+            if (_timing.CurTime < clay.NextRegenTime.Value)
+                continue;
+
+            // Try to regen one size step.
+            if (!TryComp<SizeAffectedComponent>(uid, out var sizeComp))
+            {
+                // Nothing to regen – stop timer.
+                clay.NextRegenTime = null;
+                continue;
+            }
+
+            // Stop regen if already at or above original scale.
+            if (sizeComp.ScaleMultiplier >= clay.OriginalScale - 0.001f)
+            {
+                clay.NextRegenTime = null;
+                continue;
+            }
+
+            _sizeManip.TryChangeSizeForced(uid, SizeManipulatorMode.Grow);
+
+            // Notify only the player via private chat.
+            if (TryComp<ActorComponent>(uid, out var actor))
+            {
+                _chatManager.ChatMessageToOne(
+                    ChatChannel.Emotes,
+                    Loc.GetString("clay-body-regen-message"),
+                    Loc.GetString("clay-body-regen-message"),
+                    EntityUid.Invalid,
+                    false,
+                    actor.PlayerSession.Channel);
+            }
+
+            // Check again after growing – if still below original scale, schedule next tick.
+            if (TryComp<SizeAffectedComponent>(uid, out var updatedSize) &&
+                updatedSize.ScaleMultiplier >= clay.OriginalScale - 0.001f)
+            {
+                clay.NextRegenTime = null;
+            }
+            else
+            {
+                clay.NextRegenTime = _timing.CurTime + clay.RegenInterval;
+            }
+        }
+    }
+
+    private void OnGetAlternativeVerbs(EntityUid uid, WFClayBodyComponent clay, GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!args.CanInteract || !args.CanAccess)
+            return;
+
+        var verb = new AlternativeVerb
+        {
+            Text = Loc.GetString("clay-body-verb-pluck"),
+            Act = () => PluckClay(uid, clay, args.User),
+            Priority = 1,
+        };
+
+        args.Verbs.Add(verb);
+    }
+
+    private void PluckClay(EntityUid uid, WFClayBodyComponent clay, EntityUid user)
+    {
+        // Capture original scale on first pluck.
+        if (!clay.OriginalScaleCaptured)
+        {
+            var sizeComp = EnsureComp<SizeAffectedComponent>(uid);
+            clay.OriginalScale = sizeComp.ScaleMultiplier;
+            clay.OriginalScaleCaptured = true;
+        }
+
+        // Attempt to shrink the target.
+        if (!_sizeManip.TryChangeSizeForced(uid, SizeManipulatorMode.Shrink, user))
+        {
+            _popup.PopupEntity(Loc.GetString("clay-body-pluck-fail"), uid, user, PopupType.SmallCaution);
+            return;
+        }
+
+        // Spawn a clay chunk and try to put it in the plucker's hand.
+        var userXform = Transform(user);
+        var chunk = Spawn("WFClayChunk", userXform.Coordinates);
+        if (!_hands.TryPickupAnyHand(user, chunk))
+        {
+            // No free hand — it stays on the ground where it spawned.
+        }
+
+        _popup.PopupEntity(Loc.GetString("clay-body-pluck-success-user"), uid, user, PopupType.Medium);
+        if (uid != user)
+            _popup.PopupEntity(Loc.GetString("clay-body-pluck-success-target"), uid, uid, PopupType.MediumCaution);
+
+        if (TryComp<ActorComponent>(uid, out var pluckedActor))
+        {
+            _chatManager.ChatMessageToOne(
+                ChatChannel.Emotes,
+                Loc.GetString("clay-body-pluck-chat-target"),
+                Loc.GetString("clay-body-pluck-chat-target"),
+                EntityUid.Invalid,
+                false,
+                pluckedActor.PlayerSession.Channel);
+        }
+
+        // Start or refresh the regen timer.
+        clay.NextRegenTime = _timing.CurTime + clay.RegenInterval;
+    }
+
+    private void OnInteractUsing(EntityUid uid, WFClayBodyComponent clay, InteractUsingEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        // Only react to clay chunks.
+        if (!HasComp<WFClayChunkComponent>(args.Used))
+            return;
+
+        args.Handled = true;
+
+        // Grow the target — no cap at original scale; TryChangeSizeForced caps at MaxScale.
+        if (!_sizeManip.TryChangeSizeForced(uid, SizeManipulatorMode.Grow, args.User))
+        {
+            _popup.PopupEntity(Loc.GetString("clay-body-add-fail"), uid, args.User, PopupType.SmallCaution);
+            return;
+        }
+
+        // Consume the clay chunk.
+        QueueDel(args.Used);
+
+        _popup.PopupEntity(Loc.GetString("clay-body-add-success-user"), uid, args.User, PopupType.Medium);
+        if (uid != args.User)
+            _popup.PopupEntity(Loc.GetString("clay-body-add-success-target"), uid, uid, PopupType.Medium);
+
+        if (TryComp<ActorComponent>(uid, out var addedActor))
+        {
+            _chatManager.ChatMessageToOne(
+                ChatChannel.Emotes,
+                Loc.GetString("clay-body-add-chat-target"),
+                Loc.GetString("clay-body-add-chat-target"),
+                EntityUid.Invalid,
+                false,
+                addedActor.PlayerSession.Channel);
+        }
+
+        // Cancel the regen timer if at or above original scale (no longer shrunk).
+        if (TryComp<SizeAffectedComponent>(uid, out var updatedSize) &&
+            clay.OriginalScaleCaptured &&
+            updatedSize.ScaleMultiplier >= clay.OriginalScale - 0.001f)
+        {
+            clay.NextRegenTime = null;
+        }
+    }
+}

--- a/Content.Shared/_WF/Traits/WFClayBodyComponent.cs
+++ b/Content.Shared/_WF/Traits/WFClayBodyComponent.cs
@@ -1,0 +1,37 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._WF.Traits;
+
+/// <summary>
+/// Marks an entity as having a clay body. Such entities can be "plucked" by others
+/// to remove a small amount of clay (shrinking them), which drops a ClayChunk item.
+/// The entity slowly regenerates its size over time.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
+public sealed partial class WFClayBodyComponent : Component
+{
+    /// <summary>
+    /// How long between each regen tick (grows the entity back by one size step).
+    /// </summary>
+    [DataField]
+    public TimeSpan RegenInterval = TimeSpan.FromMinutes(15);
+
+    /// <summary>
+    /// The game time at which the next regen tick should occur.
+    /// Null means the timer is not currently running (entity is at full size).
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan? NextRegenTime = null;
+
+    /// <summary>
+    /// The scale the entity should regen back to. Captured on first pluck.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float OriginalScale = 1.0f;
+
+    /// <summary>
+    /// Whether the original scale has been captured yet.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool OriginalScaleCaptured = false;
+}

--- a/Content.Shared/_WF/Traits/WFClayChunkComponent.cs
+++ b/Content.Shared/_WF/Traits/WFClayChunkComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Shared._WF.Traits;
+
+/// <summary>
+/// Marks this item as a clay chunk that was plucked from a Clay Body player.
+/// When used on a player with <see cref="WFClayBodyComponent"/>, it is consumed
+/// to restore one size step to the target.
+/// </summary>
+[RegisterComponent]
+public sealed partial class WFClayChunkComponent : Component;

--- a/Resources/Locale/en-US/_WF/traits.ftl
+++ b/Resources/Locale/en-US/_WF/traits.ftl
@@ -7,4 +7,24 @@ trait-carnivore-desc = You are a Carnivore, you can only eat products that conta
 trait-herbivore-name = Herbivore
 trait-herbivore-desc = You are a Herbivore, you can only eat products that contain plant / vegetable.
 
+trait-claybody-name = Clay Body
+trait-claybody-desc = Your body is made of living clay. Others can pluck pieces from you, and you'll slowly grow back to your full size.
+
 loadout-trait-restriction = Requires the { $trait } trait.
+
+## Clay Body system
+
+clay-body-verb-pluck = Pluck Clay
+
+clay-body-pluck-success-user = You pluck a chunk of clay from them.
+clay-body-pluck-success-target = Someone plucks a piece of you away!
+clay-body-pluck-chat-target = A piece of your body is pulled away, leaving you feeling slightly smaller.
+clay-body-pluck-fail = Their clay body can't be reduced any further.
+
+clay-body-add-success-user = You press the clay onto them.
+clay-body-add-success-target = Someone presses clay onto you — you feel a little bigger.
+clay-body-add-chat-target = Clay is pressed into your body, expanding your mass slightly.
+clay-body-add-fail = They can't take on any more clay.
+clay-body-restore-self = You can't do that to yourself.
+
+clay-body-regen-message = Your body slowly regenerates clay, restoring your mass.

--- a/Resources/Prototypes/_WF/Entities/Objects/Misc/clay_chunk.yml
+++ b/Resources/Prototypes/_WF/Entities/Objects/Misc/clay_chunk.yml
@@ -1,0 +1,26 @@
+# Clay Chunk — dropped when a Clay Body player is plucked.
+# Can be returned to the player to restore their size.
+
+- type: entity
+  parent: BaseItem
+  id: WFClayChunk
+  name: clay chunk
+  description: A warm, pliable lump of clay plucked from someone's body. It still radiates a faint life-force.
+  components:
+  - type: Sprite
+    sprite: Objects/Materials/materials.rsi
+    state: ash
+  - type: Item
+    sprite: Objects/Materials/materials.rsi
+    size: Tiny
+  - type: WFClayChunk
+  - type: Damageable
+    damageContainer: Inorganic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]

--- a/Resources/Prototypes/_WF/Traits/quirks.yml
+++ b/Resources/Prototypes/_WF/Traits/quirks.yml
@@ -28,3 +28,11 @@
   cost: 1
   components:
     - type: Herbivore
+
+- type: trait
+  id: ClayBody
+  name: trait-claybody-name
+  description: trait-claybody-desc
+  category: Quirks
+  components:
+    - type: WFClayBody


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a new "ClayBody" quirk. This makes the players body more like clay. This allows people to pluck clay from their body, and reduce their size. Though clay can be pressed back into the player to restore mass. ClayBody players will regenerate mass passive every 15 minutes back to their original size. ClayBody players can stow excess clay to regain mass past their original size.

This quirk can be selected on the lobby. I wanna pull chunks of clay off my Roy and horde his clay so i can make him big big!

**TODO:** _Make a clay chunk sprite._
The clay chunk uses the ash sprite from materials.rsi as a placeholder. A dedicated RSI sprite at e.g. Objects/Materials/clay_chunk.rsi would be needed for a proper visual.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
WFClayBodyComponent.cs: Networked component that tracks the regen timer and original scale.
WFClayChunkComponent.cs: Simple marker component for the clay chunk item.
ClayBodySystem.cs: Server system handling all three interactions.
clay_chunk.yml: WFClayChunk entity prototype.

## How to test
1. Select the quirk at lobby or add WFClayBody component on player
2. Right click and pluck clay
3. With clay in hand, click player
4. Wait to see mass regenerate
    - You can edit the component to change wait time from 15minutes.

## Media
<img width="1203" height="213" alt="image" src="https://github.com/user-attachments/assets/08c6180e-248a-428e-94dc-82ac6de52196" />
<img width="247" height="153" alt="image" src="https://github.com/user-attachments/assets/ad187365-864b-4806-a2ed-ca68dfbcb2e7" />
<img width="1075" height="466" alt="image" src="https://github.com/user-attachments/assets/d2d184fa-9a39-4274-a3bd-361fed3958bb" />
<img width="949" height="194" alt="image" src="https://github.com/user-attachments/assets/6ba21f95-3271-4d38-8020-ba1c4bff521a" />
<img width="801" height="197" alt="image" src="https://github.com/user-attachments/assets/3f9e9a1c-8f85-410b-b3f5-0442c1ce4695" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- add: Added WFClayBody Quirk
