### PR TITLE
Removes Action Button Interaction with the Custom Examine Menu

### DIFF
--- a/Content.Client/_Floof/Examine/CustomExamineSystem.cs
+++ b/Content.Client/_Floof/Examine/CustomExamineSystem.cs
@@ -22,7 +22,7 @@ public sealed class CustomExamineSystem : SharedCustomExamineSystem
     {
         base.Initialize();
         SubscribeLocalEvent<GetVerbsEvent<Verb>>(OnGetVerbs);
-        SubscribeLocalEvent<ActivateInWorldEvent>(OnActivateInWorld, after: [typeof(StrippableSystem)]);
+        //SubscribeLocalEvent<ActivateInWorldEvent>(OnActivateInWorld, after: [typeof(StrippableSystem)]); # Wayfarer: There's already a right click menu. This isn't needed.
         SubscribeLocalEvent<CustomExamineComponent, AfterAutoHandleStateEvent>(OnStateUpdate);
     }
 
@@ -41,7 +41,7 @@ public sealed class CustomExamineSystem : SharedCustomExamineSystem
             DoContactInteraction = false
         });
     }
-
+    /* // Wayfarer: Redundant. Removed.
     private void OnActivateInWorld(ActivateInWorldEvent ev)
     {
         // This one works only if user == target, because otherwise it would conflict with stripping ui
@@ -53,6 +53,7 @@ public sealed class CustomExamineSystem : SharedCustomExamineSystem
 
         OpenUi(ev.Target);
     }
+    */ //End Wayfarer: Redundant. Removed.
 
     private void OnStateUpdate(Entity<CustomExamineComponent> ent, ref AfterAutoHandleStateEvent args)
     {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
As the title says, disables pressing E/clicking yourself to open the custom examine menu, leaving only the right click verb.

## Why / Balance
By request.

## Technical details
<!-- Summary of code changes for easier review. -->
Commented one event and one block of code.

## How to test
Spawn, right click yourself. Custom examine menu still exists. Try pressing E or clicking yourself, see that it no longer opens said menu.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The custom examine menu can now only be accessed through right clicking yourself, instead of pressing the action button.
