### PR TITLE
HoverBike Nerf

### DIFF
--- a/Content.Server/_Goobstation/Vehicles/VehicleSystem.cs
+++ b/Content.Server/_Goobstation/Vehicles/VehicleSystem.cs
@@ -2,6 +2,11 @@ using Content.Shared._Goobstation.Vehicles; // Frontier: migrate under _Goobstat
 using Content.Server._NF.Radar; // Frontier
 using Content.Shared.Buckle.Components; // Frontier
 using Content.Shared._NF.Radar; // Frontier
+using Content.Shared._NF.Vehicle.Components; // Wayfarer
+using Content.Shared.Buckle; // Wayfarer
+using Content.Shared.Damage; // Wayfarer
+using Content.Shared.Stunnable; // Wayfarer
+using Robust.Shared.Random; // Wayfarer
 
 namespace Content.Server._Goobstation.Vehicles; // Frontier: migrate under _Goobstation
 
@@ -9,10 +14,23 @@ public sealed class VehicleSystem : SharedVehicleSystem
 {
     //// Frontier: extra logic (radar blips, faction stuff)
     [Dependency] private readonly RadarBlipSystem _radar = default!;
+    // Wayfarer: rider knockoff on damage
+    [Dependency] private readonly SharedBuckleSystem _buckleSystem = default!;
+    [Dependency] private readonly SharedStunSystem _stun = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    // End Wayfarer
 
     /// <summary>
     /// Configures the radar blip for a vehicle entity.
     /// </summary>
+    // Wayfarer: override Initialize to subscribe to rider damage event
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<VehicleRiderComponent, DamageChangedEvent>(OnRiderDamageChanged);
+    }
+    // End Wayfarer
+
     protected override void OnStrapped(Entity<VehicleComponent> ent, ref StrappedEvent args)
     {
         base.OnStrapped(ent, ref args);
@@ -36,4 +54,22 @@ public sealed class VehicleSystem : SharedVehicleSystem
             _radar.SetupVehicleRadarBlip(ent);
     }
     // End Frontier
+
+    // Wayfarer: knock rider off vehicle on damage with 70% chance
+    private void OnRiderDamageChanged(Entity<VehicleRiderComponent> ent, ref DamageChangedEvent args)
+    {
+        // Only trigger on actual damage, not healing
+        if (args.DamageDelta == null || !args.DamageIncreased)
+            return;
+
+        if (!_random.Prob(0.70f))
+            return;
+
+        if (!TryComp<BuckleComponent>(ent, out var buckle) || !buckle.Buckled || buckle.BuckledTo == null)
+            return;
+
+        _buckleSystem.TryUnbuckle(ent, ent, buckleComp: buckle);
+        _stun.TryKnockdown(ent.Owner, TimeSpan.FromSeconds(1), refresh: true, force: true);
+    }
+    // End Wayfarer
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Players on hoverbikes have a 70% chance to get knocked off when taking damage.

## Why / Balance
Balance of the hoverbikes being OP in combat.

## Media
[Screencast_20260509_143116.webm](https://github.com/user-attachments/assets/49b7909e-b3fc-4d9e-aead-c067d7838f82)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Changed Hoverbikes. Riders have a 70% chance of knockdown upon taking damage while riding.
