### PR TITLE
Dusk: GenPop Medical Access

### DIFF
--- a/Resources/Maps/_WF/Outpost/dusk.yml
+++ b/Resources/Maps/_WF/Outpost/dusk.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 267.3.0
   forkId: ""
   forkVersion: ""
-  time: 05/10/2026 10:14:01
-  entityCount: 20455
+  time: 05/13/2026 07:43:45
+  entityCount: 20459
 maps:
 - 1
 grids:
@@ -17825,6 +17825,24 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -56.5,-58.5
       parent: 2
+  - uid: 220
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-8.5
+      parent: 2
+  - uid: 221
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-7.5
+      parent: 2
+  - uid: 222
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-6.5
+      parent: 2
 - proto: AirlockExternalGlassNfsdLocked
   entities:
   - uid: 211
@@ -17891,32 +17909,6 @@ entities:
       parent: 2
     - type: Docking
       name: dock-label-trade-bus
-- proto: AirlockExternalLocked
-  entities:
-  - uid: 220
-    components:
-    - type: Transform
-      pos: 20.5,-6.5
-      parent: 2
-    - type: AccessReader
-      access:
-      - - Medical
-  - uid: 221
-    components:
-    - type: Transform
-      pos: 20.5,-7.5
-      parent: 2
-    - type: AccessReader
-      access:
-      - - Medical
-  - uid: 222
-    components:
-    - type: Transform
-      pos: 20.5,-8.5
-      parent: 2
-    - type: AccessReader
-      access:
-      - - Medical
 - proto: AirlockFreezer
   entities:
   - uid: 223
@@ -18740,18 +18732,18 @@ entities:
     - type: Transform
       pos: 99.5,-64.5
       parent: 2
-  - uid: 362
+  - uid: 361
     components:
     - type: Transform
       pos: 97.5,-64.5
       parent: 2
-  - uid: 363
+  - uid: 362
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 97.5,-52.5
       parent: 2
-  - uid: 364
+  - uid: 363
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18759,19 +18751,19 @@ entities:
       parent: 2
     - type: Docking
       name: dock-label-sf2
-  - uid: 365
+  - uid: 364
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 99.5,-52.5
       parent: 2
-  - uid: 366
+  - uid: 365
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 79.5,-52.5
       parent: 2
-  - uid: 367
+  - uid: 366
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18779,36 +18771,54 @@ entities:
       parent: 2
     - type: Docking
       name: dock-label-sf1
-  - uid: 368
+  - uid: 367
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 81.5,-52.5
       parent: 2
-  - uid: 369
+  - uid: 368
     components:
     - type: Transform
       pos: 79.5,-64.5
       parent: 2
-  - uid: 370
+  - uid: 369
     components:
     - type: Transform
       pos: 80.5,-64.5
       parent: 2
     - type: Docking
       name: dock-label-sa1
-  - uid: 371
+  - uid: 370
     components:
     - type: Transform
       pos: 81.5,-64.5
       parent: 2
-  - uid: 599
+  - uid: 371
     components:
     - type: Transform
       pos: 98.5,-64.5
       parent: 2
     - type: Docking
       name: dock-label-sa2
+  - uid: 453
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 23.5,-8.5
+      parent: 2
+  - uid: 454
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 23.5,-6.5
+      parent: 2
+  - uid: 455
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 23.5,-7.5
+      parent: 2
 - proto: AirlockGlassShuttleNfsdLocked
   entities:
   - uid: 372
@@ -19123,6 +19133,32 @@ entities:
     - type: AccessReader
       access:
       - - Mail
+- proto: AirlockMedical
+  entities:
+  - uid: 436
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-16.5
+      parent: 2
+  - uid: 437
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-15.5
+      parent: 2
+  - uid: 438
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-23.5
+      parent: 2
+  - uid: 441
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-16.5
+      parent: 2
 - proto: AirlockMedicalGlass
   entities:
   - uid: 430
@@ -19160,61 +19196,29 @@ entities:
     - type: Transform
       pos: 14.5,-37.5
       parent: 2
-- proto: AirlockMedicalGlassLocked
-  entities:
-  - uid: 436
-    components:
-    - type: Transform
-      pos: 13.5,-13.5
-      parent: 2
-  - uid: 437
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,-16.5
-      parent: 2
-    - type: AccessReader
-      access:
-      - - Medical
-  - uid: 438
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 11.5,-16.5
-      parent: 2
-    - type: AccessReader
-      access:
-      - - Medical
   - uid: 439
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-9.5
       parent: 2
-    - type: AccessReader
-      access:
-      - - Medical
-- proto: AirlockMedicalMorgueLocked
-  entities:
   - uid: 440
     components:
     - type: Transform
-      pos: 7.5,-14.5
-      parent: 2
-  - uid: 441
-    components:
-    - type: Transform
-      pos: 9.5,-23.5
+      rot: -1.5707963267948966 rad
+      pos: 18.5,-7.5
       parent: 2
   - uid: 442
     components:
     - type: Transform
-      pos: 18.5,-7.5
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-13.5
       parent: 2
   - uid: 443
     components:
     - type: Transform
-      pos: 14.5,-15.5
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-14.5
       parent: 2
 - proto: AirlockNfsdBrigGlassLocked
   entities:
@@ -19270,28 +19274,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 7.5,-88.5
       parent: 2
-- proto: AirlockShuttle
-  entities:
-  - uid: 453
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 23.5,-6.5
-      parent: 2
-  - uid: 454
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 23.5,-8.5
-      parent: 2
-  - uid: 455
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 23.5,-7.5
-      parent: 2
-    - type: Docking
-      name: dock-label-medical
 - proto: AirSensorVox
   entities:
   - uid: 456
@@ -20139,301 +20121,301 @@ entities:
       parent: 2
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 361
-    components:
-    - type: Transform
-      pos: 98.5,-64.5
-      parent: 2
   - uid: 548
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -47.5,-55.5
+      pos: 98.5,-64.5
       parent: 2
   - uid: 549
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -48.5,-55.5
+      pos: -47.5,-55.5
       parent: 2
   - uid: 550
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -48.5,-55.5
+      parent: 2
+  - uid: 551
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,-35.5
       parent: 2
-  - uid: 551
+  - uid: 552
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 44.5,-86.5
       parent: 2
-  - uid: 552
+  - uid: 553
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -35.5,-86.5
       parent: 2
-  - uid: 553
+  - uid: 554
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.5,-35.5
       parent: 2
-  - uid: 554
+  - uid: 555
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,-99.5
       parent: 2
-  - uid: 555
+  - uid: 556
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,-150.5
       parent: 2
-  - uid: 556
+  - uid: 557
     components:
     - type: Transform
       pos: 6.5,-179.5
       parent: 2
-  - uid: 557
+  - uid: 558
     components:
     - type: Transform
       pos: 2.5,-179.5
       parent: 2
-  - uid: 558
+  - uid: 559
     components:
     - type: Transform
       pos: 3.5,-179.5
       parent: 2
-  - uid: 559
+  - uid: 560
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,-149.5
       parent: 2
-  - uid: 560
-    components:
-    - type: Transform
-      pos: 5.5,-179.5
-      parent: 2
   - uid: 561
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -29.5,-151.5
+      pos: 5.5,-179.5
       parent: 2
   - uid: 562
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -29.5,-152.5
+      pos: -29.5,-151.5
       parent: 2
   - uid: 563
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -29.5,-153.5
+      pos: -29.5,-152.5
       parent: 2
   - uid: 564
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 38.5,-152.5
+      rot: -1.5707963267948966 rad
+      pos: -29.5,-153.5
       parent: 2
   - uid: 565
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 38.5,-151.5
+      pos: 38.5,-152.5
       parent: 2
   - uid: 566
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 38.5,-150.5
+      pos: 38.5,-151.5
       parent: 2
   - uid: 567
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 38.5,-149.5
+      pos: 38.5,-150.5
       parent: 2
   - uid: 568
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 38.5,-153.5
+      pos: 38.5,-149.5
       parent: 2
   - uid: 569
     components:
     - type: Transform
-      pos: 4.5,-179.5
+      rot: 1.5707963267948966 rad
+      pos: 38.5,-153.5
       parent: 2
   - uid: 570
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 38.5,-129.5
+      pos: 4.5,-179.5
       parent: 2
   - uid: 571
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 38.5,-130.5
+      pos: 38.5,-129.5
       parent: 2
   - uid: 572
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 38.5,-132.5
+      pos: 38.5,-130.5
       parent: 2
   - uid: 573
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 38.5,-128.5
+      pos: 38.5,-132.5
       parent: 2
   - uid: 574
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 38.5,-131.5
+      pos: 38.5,-128.5
       parent: 2
   - uid: 575
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 38.5,-131.5
+      parent: 2
+  - uid: 576
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,-32.5
       parent: 2
-  - uid: 576
+  - uid: 577
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 80.5,-52.5
       parent: 2
-  - uid: 577
+  - uid: 578
     components:
     - type: Transform
       pos: 135.5,-93.5
       parent: 2
-  - uid: 578
-    components:
-    - type: Transform
-      pos: 134.5,-93.5
-      parent: 2
   - uid: 579
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 134.5,-22.5
+      pos: 134.5,-93.5
       parent: 2
   - uid: 580
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 135.5,-22.5
+      pos: 134.5,-22.5
       parent: 2
   - uid: 581
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 136.5,-22.5
+      pos: 135.5,-22.5
       parent: 2
   - uid: 582
     components:
     - type: Transform
-      pos: 136.5,-93.5
+      rot: 3.141592653589793 rad
+      pos: 136.5,-22.5
       parent: 2
   - uid: 583
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 141.5,-88.5
+      pos: 136.5,-93.5
       parent: 2
   - uid: 584
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 141.5,-86.5
+      pos: 141.5,-88.5
       parent: 2
   - uid: 585
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 141.5,-87.5
+      pos: 141.5,-86.5
       parent: 2
   - uid: 586
     components:
     - type: Transform
-      pos: 116.5,-64.5
+      rot: 1.5707963267948966 rad
+      pos: 141.5,-87.5
       parent: 2
   - uid: 587
     components:
     - type: Transform
-      pos: 117.5,-64.5
+      pos: 116.5,-64.5
       parent: 2
   - uid: 588
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 115.5,-52.5
+      pos: 117.5,-64.5
       parent: 2
   - uid: 589
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 116.5,-52.5
+      pos: 115.5,-52.5
       parent: 2
   - uid: 590
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 117.5,-52.5
+      pos: 116.5,-52.5
       parent: 2
   - uid: 591
     components:
     - type: Transform
-      pos: 115.5,-64.5
+      rot: 3.141592653589793 rad
+      pos: 117.5,-52.5
       parent: 2
   - uid: 592
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 141.5,-28.5
+      pos: 115.5,-64.5
       parent: 2
   - uid: 593
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 141.5,-29.5
+      pos: 141.5,-28.5
       parent: 2
   - uid: 594
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 141.5,-27.5
+      pos: 141.5,-29.5
       parent: 2
   - uid: 595
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 141.5,-58.5
+      pos: 141.5,-27.5
       parent: 2
   - uid: 596
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 141.5,-57.5
+      pos: 141.5,-58.5
       parent: 2
   - uid: 597
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 141.5,-59.5
+      pos: 141.5,-57.5
       parent: 2
   - uid: 598
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 141.5,-59.5
+      parent: 2
+  - uid: 599
     components:
     - type: Transform
       pos: 99.5,-64.5
@@ -62736,6 +62718,30 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,-100.5
+      parent: 2
+  - uid: 20444
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 39.5,-34.5
+      parent: 2
+  - uid: 20445
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -30.5,-34.5
+      parent: 2
+  - uid: 20446
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -32.5,-87.5
+      parent: 2
+  - uid: 20447
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 41.5,-87.5
       parent: 2
 - proto: ComputerStationRecords
   entities:
@@ -115321,7 +115327,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: -61.5,-59.5
       parent: 2
-  - uid: 20444
+  - uid: 20448
     components:
     - type: Transform
       anchored: False
@@ -115330,7 +115336,7 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Dynamic
-  - uid: 20445
+  - uid: 20449
     components:
     - type: Transform
       anchored: False
@@ -115338,7 +115344,7 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Dynamic
-  - uid: 20446
+  - uid: 20450
     components:
     - type: Transform
       anchored: False
@@ -115346,7 +115352,7 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Dynamic
-  - uid: 20447
+  - uid: 20451
     components:
     - type: Transform
       anchored: False
@@ -115355,7 +115361,7 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Dynamic
-  - uid: 20448
+  - uid: 20452
     components:
     - type: Transform
       anchored: False
@@ -115364,7 +115370,7 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Dynamic
-  - uid: 20449
+  - uid: 20453
     components:
     - type: Transform
       anchored: False
@@ -115373,7 +115379,7 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Dynamic
-  - uid: 20450
+  - uid: 20454
     components:
     - type: Transform
       anchored: False
@@ -115381,7 +115387,7 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Dynamic
-  - uid: 20451
+  - uid: 20455
     components:
     - type: Transform
       anchored: False
@@ -115390,7 +115396,7 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Dynamic
-  - uid: 20452
+  - uid: 20456
     components:
     - type: Transform
       anchored: False
@@ -115399,7 +115405,7 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Dynamic
-  - uid: 20453
+  - uid: 20457
     components:
     - type: Transform
       anchored: False
@@ -115408,7 +115414,7 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Dynamic
-  - uid: 20454
+  - uid: 20458
     components:
     - type: Transform
       anchored: False
@@ -115417,7 +115423,7 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Dynamic
-  - uid: 20455
+  - uid: 20459
     components:
     - type: Transform
       anchored: False


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Closes https://github.com/project-wayfarer/wayfarer-14/issues/858

## Why / Balance
By request, reverts dusk medical access to genpop.

Note: If genpop access is not desired when there is a DoC, they can lock the access with an access configurator/civilian access configurator.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Dusk medical access reverted to genpop.