### PR TITLE
Prevent ToggleableClothing from covering AttachedClothing

### DIFF
--- a/Content.Shared/_WF/Clothing/EntitySystems/ToggleableClothingSystem.UnderClothing.cs
+++ b/Content.Shared/_WF/Clothing/EntitySystems/ToggleableClothingSystem.UnderClothing.cs
@@ -4,14 +4,14 @@ namespace Content.Shared.Clothing.EntitySystems;
 
 /// <summary>
 /// Extends upstream's ToggleableClothingSystem.
-/// 
-/// Provides methods that store and re-equip clothing when toggleable clothing is put on or taken off. 
+///
+/// Provides methods that store and re-equip clothing when toggleable clothing is put on or taken off.
 /// God, I hate naming things.
 /// </summary>
 public sealed partial class ToggleableClothingSystem : EntitySystem
 {
     /// <summary>
-    ///     Tries to store clothing in <see cref="ToggleableClothingComponent.UnderClothingContainer"/> 
+    ///     Tries to store clothing in <see cref="ToggleableClothingComponent.UnderClothingContainer"/>
     /// </summary>
     /// <param name="clothing">The clothing to be stored.</param>
     /// <param name="component">The ToggleableClothingComponent to store the clothing in.</param>
@@ -19,6 +19,10 @@ public sealed partial class ToggleableClothingSystem : EntitySystem
     private bool TryStoreUnderClothing(EntityUid clothing, ToggleableClothingComponent component)
     {
         if (component.UnderClothingContainer == null)
+            return false;
+
+        // Don't allow storing other toggleable clothing's attached equippables
+        if (HasComp<AttachedClothingComponent>(clothing))
             return false;
 
         // There is already something in there? Either way, return false because we


### PR DESCRIPTION
## About the PR
Prevents togglable clothing (hardsuits, cloaks with hoods) from covering an item that is considered Attached (like a suit's helmet, or a cloak's hood)

## Why / Balance
Resolves #515 
These were colliding and causing all sorts of issues, namely making people go bald, or fusing helmets to their face.

## Technical details
When attempting to toggle a clothing item (hardsuit, as example), the code now checks the clothing item that would be stored in the `ToggleableClothingComponent`'s `UnderClothingContainer` (goliath hood as example). If the clothing item (goliath hood) has an `AttachedClothingComponent`, don't toggle the clothing.

## How to test
- Build/Run/Join
- Spawn and equip:
  - Hooded cloak (goliath for example)
  - Hardsuit
  - Any hat
- Toggle the hardsuit
  - It covers the hat as expected
- Attempt to toggle the cloak
  - A message tells you to unequip the attached hood/helmet first
- Untoggle the hardsuit's helmet
  - The hat you equipped earlier is returned to your head
- If you're nasty, repeat with the cloak first, hardsuit second

## Media
https://github.com/user-attachments/assets/7d5fe74a-acc6-4cc7-8837-d7f0b6acf68c

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Toggling a hooded cloak and hardsuit in the wrong order no longer gives you a surprise buzz-cut