### PR TITLE
Science Research Point Multiplier Framework

### DIFF
--- a/Content.Server/Anomaly/AnomalySystem.cs
+++ b/Content.Server/Anomaly/AnomalySystem.cs
@@ -22,6 +22,8 @@ using Robust.Shared.Timing; // Frontier
 using Content.Server.Stack; // Frontier
 using Content.Shared._NF.Anomaly; // Frontier
 
+using Content.Shared._WF.CCVar; // Wayfarer
+
 namespace Content.Server.Anomaly;
 
 /// <summary>
@@ -181,7 +183,7 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
 
         var severityValue = 1 / (1 + MathF.Pow(MathF.E, -7 * (component.Severity - 0.5f)));
 
-        return (int)((component.MaxPointsPerSecond - component.MinPointsPerSecond) * severityValue * multiplier) + component.MinPointsPerSecond;
+        return (int)((((component.MaxPointsPerSecond - component.MinPointsPerSecond) * severityValue * multiplier) + component.MinPointsPerSecond) * _configuration.GetCVar(WFCVars.AnomalyPointMultiplier)); // Wayfarer: Add * _configuration.GetCVar(WFCVars.AnomalyPointMultiplier)
     }
 
     /// <summary>

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
@@ -411,6 +411,7 @@ public abstract partial class SharedXenoArtifactSystem
         if (node.Comp.ArtifexiumUsed)
             nodeComponent.ResearchValue = (int)Math.Pow(nodeComponent.ResearchValue - 700, 0.9);
         // End Frontier: remove value from using artifexium, different value sets
+
         nodeComponent.ResearchValue = (int)(nodeComponent.ResearchValue * _cfg.GetCVar(WFCVars.ArtifactPointMultiplier)); // Wayfarer: Apply the research multiplier.
     }
 

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
@@ -8,6 +8,8 @@ using Robust.Shared.Utility;
 using Content.Shared._NF.CCVar; // Frontier
 using Robust.Shared.Configuration; // Frontier
 
+using Content.Shared._WF.CCVar; // Wayfarer
+
 namespace Content.Shared.Xenoarchaeology.Artifact;
 
 public abstract partial class SharedXenoArtifactSystem
@@ -409,7 +411,7 @@ public abstract partial class SharedXenoArtifactSystem
         if (node.Comp.ArtifexiumUsed)
             nodeComponent.ResearchValue = (int)Math.Pow(nodeComponent.ResearchValue - 700, 0.9);
         // End Frontier: remove value from using artifexium, different value sets
-
+        nodeComponent.ResearchValue = (int)(nodeComponent.ResearchValue * _cfg.GetCVar(WFCVars.ArtifactPointMultiplier)); // Wayfarer: Apply the research multiplier.
     }
 
     // Frontier: ensure single use nodes

--- a/Content.Shared/_WF/CCVar/CCVars.Wayfarer.cs
+++ b/Content.Shared/_WF/CCVar/CCVars.Wayfarer.cs
@@ -1,0 +1,22 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._WF.CCVar;
+
+/// <summary>
+/// Contains CVars used by Wayfarer.
+/// </summary>
+[CVarDefs]
+public sealed class WFCVars
+{
+    /// <summary>
+    /// Anomaly research point multiplier. Default of 0.70 (70%) Lower than one is a penalty, higher than one is a bonus.
+    /// </summary>
+    public static readonly CVarDef<float> AnomalyPointMultiplier =
+    CVarDef.Create("wf.research.anomaly_multiplier", 0.70f, CVar.SERVER | CVar.REPLICATED);
+
+    /// <summary>
+    /// Artifact research point multiplier. Default of 0.90 (90%) Lower than one is a penalty, higher than one is a bonus.
+    /// </summary>
+    public static readonly CVarDef<float> ArtifactPointMultiplier =
+    CVarDef.Create("wf.research.artifact_multiplier", 0.90f, CVar.SERVER | CVar.REPLICATED);
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a very small set of cvars that can multiply the research point value of both anomalies and artifacts on the fly.

Meant to be used by admins, server hosts and coders.

## Why / Balance
I currently have set it to a multiplier that gives both types of science a penalty, with a 30% points penalty to anomaly science and 10% penalty to artifact science, by request.

This is however, a framework that can be modified by things such as events, so if you want to, for example, make an event or community actions that sway these, this can easily be done by altering the cvars.

## Technical details
One set of cvars and two lines. Doesn't get simpler than this.

## How to test
Research artifacts or anomalies, verify the multipliers are taking effect.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added mutable server configuration variables that can modify how many points certain sources of science can give.
