### PR TITLE
Takes Omni Blueprints Out Back and Shoots Them

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Tools/blueprints/blueprints_base.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Tools/blueprints/blueprints_base.yml
@@ -198,7 +198,7 @@
   - type: Tag
     tags:
     - NFBlueprintEngineeringTechfab
-    - NFBlueprintAdvanced
+    #- NFBlueprintAdvanced # Wayfarer: Omni BP Removal
     - Document
     - Paper
 
@@ -237,7 +237,7 @@
   - type: Tag
     tags:
     - NFBlueprintSalvageTechfab
-    - NFBlueprintAdvanced
+    #- NFBlueprintAdvanced # Wayfarer: Omni BP Removal
     - Document
     - Paper
 
@@ -276,7 +276,7 @@
   - type: Tag
     tags:
     - NFBlueprintProtolathe
-    - NFBlueprintAdvanced
+    #- NFBlueprintAdvanced # Wayfarer: Omni BP Removal
     - Document
     - Paper
 
@@ -315,7 +315,7 @@
   - type: Tag
     tags:
     - NFBlueprintServiceTechfab
-    - NFBlueprintAdvanced
+    #- NFBlueprintAdvanced # Wayfarer: Omni BP Removal
     - Document
     - Paper
 
@@ -354,7 +354,7 @@
   - type: Tag
     tags:
     - NFBlueprintMedicalTechfab
-    - NFBlueprintAdvanced
+    #- NFBlueprintAdvanced # Wayfarer: Omni BP Removal
     - Document
     - Paper
 
@@ -393,7 +393,7 @@
   - type: Tag
     tags:
     - NFBlueprintMercenaryTechfab
-    - NFBlueprintAdvanced
+    #- NFBlueprintAdvanced # Wayfarer: Omni BP Removal
     - Document
     - Paper
 
@@ -431,7 +431,7 @@
   - type: Tag
     tags:
     - NFBlueprintNfsdTechfab
-    - NFBlueprintAdvanced
+    #- NFBlueprintAdvanced # Wayfarer: Omni BP Removal
     - Document
     - Paper
 
@@ -486,7 +486,7 @@
   - type: Tag
     tags:
     - NFBlueprintSalvageTechfab
-    - NFBlueprintAdvanced
+    #- NFBlueprintAdvanced # Wayfarer: Omni BP Removal
     - Document
     - Paper
 
@@ -526,6 +526,6 @@
     tags:
     - NFBlueprintMercenaryTechfab
     - NFBlueprintNfsdTechfab
-    - NFBlueprintAdvanced
+    #- NFBlueprintAdvanced # Wayfarer: Omni BP Removal
     - Document
     - Paper

--- a/Resources/Prototypes/_NF/Research/blueprints.yml
+++ b/Resources/Prototypes/_NF/Research/blueprints.yml
@@ -14,6 +14,7 @@
   #- NFBlueprintsSalvage
   #- NFBlueprintsScience
   #- NFBlueprintsService
+  - WFBlueprintsCommon
   # End Wayfarer
 
 - type: blueprint

--- a/Resources/Prototypes/_NF/Research/blueprints.yml
+++ b/Resources/Prototypes/_NF/Research/blueprints.yml
@@ -15,7 +15,7 @@
   #- NFBlueprintsScience
   #- NFBlueprintsService
   - WFBlueprintsCommon
-  # End Wayfarer
+  # Wayfarer End
 
 - type: blueprint
   id: NFEngineering

--- a/Resources/Prototypes/_NF/Research/blueprints.yml
+++ b/Resources/Prototypes/_NF/Research/blueprints.yml
@@ -4,15 +4,17 @@
   blueprint: NFBlueprintGeneral
   packs:
   - NFBlueprintsCommon
-  - NFBlueprintsEngineering
-  - NFBlueprintsEngineeringScience
-  - NFBlueprintsMedical
-  - NFBlueprintsMercenary
-  - NFBlueprintsMercenaryNfsd
-  - NFBlueprintsNfsd
-  - NFBlueprintsSalvage
-  - NFBlueprintsScience
-  - NFBlueprintsService
+  # Wayfarer: Omni BP Removal, leaves common though.
+  #- NFBlueprintsEngineering
+  #- NFBlueprintsEngineeringScience
+  #- NFBlueprintsMedical
+  #- NFBlueprintsMercenary
+  #- NFBlueprintsMercenaryNfsd
+  #- NFBlueprintsNfsd
+  #- NFBlueprintsSalvage
+  #- NFBlueprintsScience
+  #- NFBlueprintsService
+  # End Wayfarer
 
 - type: blueprint
   id: NFEngineering

--- a/Resources/Prototypes/_WF/Recipes/Lathes/Packs/blueprints.yml
+++ b/Resources/Prototypes/_WF/Recipes/Lathes/Packs/blueprints.yml
@@ -9,5 +9,4 @@
   - NFPouchContractor
   # Beakers and Vials
   - BluespaceBeaker
-  - JugBluespace
   - VialBluespace

--- a/Resources/Prototypes/_WF/Recipes/Lathes/Packs/blueprints.yml
+++ b/Resources/Prototypes/_WF/Recipes/Lathes/Packs/blueprints.yml
@@ -1,0 +1,13 @@
+  # Wayfarer Common Recipes: An Addition for the Common BP System, as we got rid of omni bps.
+- type: latheRecipePack
+  id: WFBlueprintsCommon
+  recipes:
+  # Utility
+  - RPED
+  - HandHeldMassScanner
+  - NFPouchUtility
+  - NFPouchContractor
+  # Beakers and Vials
+  - BluespaceBeaker
+  - JugBluespace
+  - VialBluespace


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Reduces the set of omni blueprints to only encompass "common" blueprints. That's bags, power cells, and baseline suits pretty much. No more omni everything with all the items in the game.

## Why / Balance
Omni blueprints are not good for what we are doing, put simply. This approach keeps the common and reasonable side of things, while removing things like the ability to print prototype hardsuits and guns out of a service lathe.

## Technical details
yaml.

## How to test
Research things, check the blueprint lithograph's all available section.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Omni blueprints have been largely removed, saved for common items.
