### PR TITLE
prevent random events targeting inactive shuttles

### DIFF
--- a/Content.Server/_CS/ShuttleCrewStatus/ShuttleCrewStatusSystem.cs
+++ b/Content.Server/_CS/ShuttleCrewStatus/ShuttleCrewStatusSystem.cs
@@ -1,9 +1,11 @@
 using Content.Server.GameTicking;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Systems;
+using Content.Server.Station.Components; // Wayfarer
 using Content.Shared.GameTicking;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Shuttles.Systems;
+using Content.Shared.Station.Components; // Wayfarer
 using Robust.Shared.Enums;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
@@ -100,17 +102,32 @@ public sealed class ShuttleCrewStatusSystem : EntitySystem
                     {
                         _shuttle.SetIFFColor(uid, crewStatus.OriginalColor.Value, iff);
                     }
+
+                    // Wayfarer: Ensure StationEventEligibleComponent, allowing random events to target active shuttles
+                    if (TryComp(uid, out StationMemberComponent? stationMember))
+                    {
+                        EnsureComp<StationEventEligibleComponent>(stationMember.Station);
+                    }
                 }
                 else
                 {
                     // Store current color if we haven't already
-                    if (!crewStatus.OriginalColor.HasValue)
+                    if (!crewStatus.OriginalColor.HasValue
+                        // Wayfarer: or if current IFF isn't inactive color & doesn't match what's stored
+                        || (iff.Color != _inactiveCrewColor && crewStatus.OriginalColor != iff.Color))
                     {
                         crewStatus.OriginalColor = iff.Color;
                     }
 
                     // Set to gray to indicate no active crew
                     _shuttle.SetIFFColor(uid, _inactiveCrewColor, iff);
+
+                    // Wayfarer: Prevent random events from targeting inactive shuttles
+                    if (TryComp(uid, out StationMemberComponent? stationMember) &&
+                        HasComp<StationEventEligibleComponent>(stationMember.Station))
+                    {
+                        RemComp<StationEventEligibleComponent>(stationMember.Station);
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removes the `StationEventEligibleComponent` from a shuttle's 'Station' when the shuttle goes inactive, restore it once active again.

This component's presence on a Station entity is what determines if it is eligible for selection by `TryGetRandomStation` (`Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs`)

This also tweaks the `ShuttleCrewStatusSystem` to not collide with an IFF color change, either through a future feature or via admin tools

## Why / Balance
https://discord.com/channels/1452368461832523919/1452399892810043585/1504496738336243913

## Technical details
When the shuttle goes inactive, find the shuttle's station entity, then check for a `StationEventEligibleComponent`. If the `StationEventEligibleComponent` is present, remove it.

When a shuttle goes active, find the shuttle's station entity, `EnsureComp` checks for a `StationEventEligibleComponent` and instantiates it if not present.

## How to test
- Purchase a shuttle in-game
- Move your character/aghost onto the shuttle, waiting a few moments to ensure it is considered active
- In console, add a random event's gamerule to force it to occur, `addgamerule NFBreakerFlip` for example
  - You should see the effects take place on the shuttle
- Repeat without entering the shuttle, ensuring it is considered inactive.
  - You should see no effects take place on the shuttle


## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Any events which rely upon `StationEventEligibleComponent` (whether through `TryGetRandomStation` or otherwise) that also **_should target inactive shuttles_** will no longer target inactive shuttles. As far as I understand though this is intended.

Any non-shuttle grids which have somehow acquired the `ShuttleCrewStatusComponent` will suddenly start being affected by events while 'active'. This should already be handled by `ShuttleCrewStatusSystem`'s `OnIFFMapInit`, though, which only gives this component to grids with `ShuttleComponent` that are player-owned.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: 
- tweak: Bluespace events no longer target shuttles which are considered 'inactive' (gray IFF).
