### PR TITLE
Removed quanteey mentions in favour of CGP outpost

### DIFF
--- a/Resources/ServerInfo/_WF/Guidebook/Rules/D1.xml
+++ b/Resources/ServerInfo/_WF/Guidebook/Rules/D1.xml
@@ -3,7 +3,7 @@
 
  - Dusk Station and 200 meters around Dusk, is a safe zone.  You are not to be engaging in any PvP, griefing or other antagonistic activity within this space.
  - Medical Dispatch and Edison are lite-safe zones, and you are not to be engaging in PvP or griefing.  Although you can conduct antagonistic activity in these locations.
- - The Quanteey is a safe zone, you cannot engage in PvP, griefing or outlaw activity, although outlaws can aHelp to request that this be lifted.  This will be confirmed with CGP so that both sides can prepare.
+ - The CGP Outpost is a safe zone, you cannot engage in PvP, griefing or outlaw activity, although outlaws can aHelp to request that this be lifted.  This will be confirmed with CGP so that both sides can prepare.
  - Perdition is a safe zone, you cannot engage in PvP, griefing or CGP activity, although CGP can aHelp to request that this be lifted. This will be confirmed with Outlaws so that both sides can prepare.
  - Characters fleeing to a safe zone are to be disengaged, unless they are CGP fleeing to Quanteey or an Outlaw fleeing to Perdition.  In which case you can pursue them and the safezone is briefly lifted for that scene.
  - Dangerous research on anomalies or artifacts are not to be done within Safe Zones or Lite-Safe Zones


### PR DESCRIPTION

## About the PR
Fixed error in rules, renamed the quanteey to CGP outpost

## Why / Balance
supposed to say outpost

## Technical details
none just xml files

## How to test
open guidebook
go to rule section

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- fix: Fixed typo in rules, make sure to read safe zone rules again carefully!
