### PR TITLE
Global crew manifest + SSD indicators for crew manifest, monitor, and crit implant tracker

### DIFF
--- a/Content.Client/CartridgeLoader/Cartridges/CrewManifestUi.cs
+++ b/Content.Client/CartridgeLoader/Cartridges/CrewManifestUi.cs
@@ -24,6 +24,6 @@ public sealed partial class CrewManifestUi : UIFragment
         if (state is not CrewManifestUiState crewManifestState)
             return;
 
-        _fragment?.UpdateState(crewManifestState.StationName, crewManifestState.Entries);
+        _fragment?.UpdateState(crewManifestState.Entries); // coyote: remove name
     }
 }

--- a/Content.Client/CartridgeLoader/Cartridges/CrewManifestUi.cs
+++ b/Content.Client/CartridgeLoader/Cartridges/CrewManifestUi.cs
@@ -24,6 +24,6 @@ public sealed partial class CrewManifestUi : UIFragment
         if (state is not CrewManifestUiState crewManifestState)
             return;
 
-        _fragment?.UpdateState(crewManifestState.Entries); // coyote: remove name
+        _fragment?.UpdateState(crewManifestState.Entries); // Coyote: remove name
     }
 }

--- a/Content.Client/CartridgeLoader/Cartridges/CrewManifestUiFragment.xaml.cs
+++ b/Content.Client/CartridgeLoader/Cartridges/CrewManifestUiFragment.xaml.cs
@@ -19,13 +19,13 @@ public sealed partial class CrewManifestUiFragment : BoxContainer
         VerticalExpand = true;
     }
 
-    public void UpdateState(string stationName, CrewManifestEntries? entries)
+    public void UpdateState(CrewManifestEntries? entries) // coyote: remove name
     {
         CrewManifestListing.DisposeAllChildren();
         CrewManifestListing.RemoveAllChildren();
 
         StationNameContainer.Visible = entries != null;
-        StationName.Text = stationName;
+        StationName.Text = "Crew Manifest"; // coyote: remove name
 
         if (entries == null)
             return;

--- a/Content.Client/CartridgeLoader/Cartridges/CrewManifestUiFragment.xaml.cs
+++ b/Content.Client/CartridgeLoader/Cartridges/CrewManifestUiFragment.xaml.cs
@@ -19,13 +19,13 @@ public sealed partial class CrewManifestUiFragment : BoxContainer
         VerticalExpand = true;
     }
 
-    public void UpdateState(CrewManifestEntries? entries) // coyote: remove name
+    public void UpdateState(CrewManifestEntries? entries) // Coyote: remove name
     {
         CrewManifestListing.DisposeAllChildren();
         CrewManifestListing.RemoveAllChildren();
 
         StationNameContainer.Visible = entries != null;
-        StationName.Text = Loc.GetString("crew-manifest-window-title"); // coyote: remove name
+        StationName.Text = Loc.GetString("crew-manifest-window-title"); // Coyote: remove name
 
         if (entries == null)
             return;

--- a/Content.Client/CartridgeLoader/Cartridges/CrewManifestUiFragment.xaml.cs
+++ b/Content.Client/CartridgeLoader/Cartridges/CrewManifestUiFragment.xaml.cs
@@ -25,7 +25,7 @@ public sealed partial class CrewManifestUiFragment : BoxContainer
         CrewManifestListing.RemoveAllChildren();
 
         StationNameContainer.Visible = entries != null;
-        StationName.Text = "Crew Manifest"; // coyote: remove name
+        StationName.Text = Loc.GetString("crew-manifest-window-title"); // coyote: remove name
 
         if (entries == null)
             return;

--- a/Content.Client/CrewManifest/CrewManifestEui.cs
+++ b/Content.Client/CrewManifest/CrewManifestEui.cs
@@ -43,6 +43,6 @@ public sealed class CrewManifestEui : BaseEui
             return;
         }
 
-        _window.Populate(cast.StationName, cast.Entries);
+        _window.Populate(cast.Entries); // Coyote: Remove name
     }
 }

--- a/Content.Client/CrewManifest/CrewManifestUi.xaml.cs
+++ b/Content.Client/CrewManifest/CrewManifestUi.xaml.cs
@@ -16,13 +16,13 @@ public sealed partial class CrewManifestUi : DefaultWindow
         StationName.AddStyleClass("LabelBig");
     }
 
-    public void Populate(string name, CrewManifestEntries? entries)
+    public void Populate(CrewManifestEntries? entries) // Coyote: Remove name
     {
         CrewManifestListing.DisposeAllChildren();
         CrewManifestListing.RemoveAllChildren();
 
         StationNameContainer.Visible = entries != null;
-        StationName.Text = name;
+        StationName.Text = "Crew Manifest"; // Coyote: Remove name
 
         if (entries == null)
             return;

--- a/Content.Client/CrewManifest/CrewManifestUi.xaml.cs
+++ b/Content.Client/CrewManifest/CrewManifestUi.xaml.cs
@@ -22,7 +22,7 @@ public sealed partial class CrewManifestUi : DefaultWindow
         CrewManifestListing.RemoveAllChildren();
 
         StationNameContainer.Visible = entries != null;
-        StationName.Text = "Crew Manifest"; // Coyote: Remove name
+        StationName.Text = Loc.GetString("crew-manifest-window-title"); // Coyote: Remove name
 
         if (entries == null)
             return;

--- a/Content.Client/CrewManifest/UI/CrewManifestSection.cs
+++ b/Content.Client/CrewManifest/UI/CrewManifestSection.cs
@@ -41,7 +41,8 @@ public sealed class CrewManifestSection : BoxContainer
             };
             name.SetMessage(entry.Name);
 
-            var inactiveLabel = new Label() // Wayfarer: Inactivity indicator for SSD characters
+            // Wayfarer: Inactivity indicator for SSD characters
+            var inactiveLabel = new Label()
             {
                 SetWidth = 5,
                 StyleClasses = { "LabelSubText" },
@@ -49,6 +50,7 @@ public sealed class CrewManifestSection : BoxContainer
                 Align = Label.AlignMode.Right,
                 Text = section.Name == "department-Inactive" ? "Zzz" : "",
             };
+            // End Wayfarer
 
             var titleContainer = new BoxContainer()
             {

--- a/Content.Client/CrewManifest/UI/CrewManifestSection.cs
+++ b/Content.Client/CrewManifest/UI/CrewManifestSection.cs
@@ -28,7 +28,7 @@ public sealed class CrewManifestSection : BoxContainer
         var gridContainer = new GridContainer()
         {
             HorizontalExpand = true,
-            Columns = 2
+            Columns = 3 // Wayfarer: 2 < 3
         };
 
         AddChild(gridContainer);
@@ -40,6 +40,15 @@ public sealed class CrewManifestSection : BoxContainer
                 HorizontalExpand = true,
             };
             name.SetMessage(entry.Name);
+
+            var inactiveLabel = new Label() // Wayfarer: Inactivity indicator for SSD characters
+            {
+                SetWidth = 5,
+                StyleClasses = { "LabelSubText" },
+                FontColorOverride = new Color(9, 169, 9),
+                Align = Label.AlignMode.Right,
+                Text = section.Name == "department-Inactive" ? "Zzz" : "",
+            };
 
             var titleContainer = new BoxContainer()
             {
@@ -70,6 +79,7 @@ public sealed class CrewManifestSection : BoxContainer
             }
 
             gridContainer.AddChild(name);
+            gridContainer.AddChild(inactiveLabel); // Wayfarer: Inactivity indicator for SSD characters
             gridContainer.AddChild(titleContainer);
         }
     }

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
@@ -280,6 +280,16 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
 
             statusContainer.AddChild(nameLabel);
 
+            var inactiveLabel = new Label() // Wayfarer: Inactivity indicator for SSD characters
+            {
+                SetWidth = 5,
+                StyleClasses = { "LabelSubText" },
+                FontColorOverride = new Color(9, 169, 9),
+                Align = Label.AlignMode.Right,
+                Text = sensor.IsSpaceSleepDisorder ? "Zzz" : "",
+            };
+            statusContainer.AddChild(inactiveLabel); // Wayfarer
+
             // User job container
             var jobContainer = new BoxContainer()
             {

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
@@ -280,7 +280,8 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
 
             statusContainer.AddChild(nameLabel);
 
-            var inactiveLabel = new Label() // Wayfarer: Inactivity indicator for SSD characters
+            // Wayfarer: Inactivity indicator for SSD characters
+            var inactiveLabel = new Label()
             {
                 SetWidth = 5,
                 StyleClasses = { "LabelSubText" },
@@ -288,7 +289,9 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
                 Align = Label.AlignMode.Right,
                 Text = sensor.IsSpaceSleepDisorder ? "Zzz" : "",
             };
-            statusContainer.AddChild(inactiveLabel); // Wayfarer
+            statusContainer.AddChild(inactiveLabel);
+            // End Wayfarer
+
 
             // User job container
             var jobContainer = new BoxContainer()

--- a/Content.Client/_WF/CartridgeLoader/Cartridges/CriticalImplantTrackerUiFragment.xaml.cs
+++ b/Content.Client/_WF/CartridgeLoader/Cartridges/CriticalImplantTrackerUiFragment.xaml.cs
@@ -92,7 +92,8 @@ public sealed partial class CriticalImplantTrackerUiFragment : BoxContainer
             };
             headerContainer.AddChild(nameLabel);
 
-            var inactiveLabel = new Label() // Wayfarer: Inactivity indicator for SSD characters
+            // Inactivity indicator for SSD characters
+            var inactiveLabel = new Label()
             {
                 StyleClasses = { "LabelSubText" },
                 FontColorOverride = new Color(9, 169, 9),

--- a/Content.Client/_WF/CartridgeLoader/Cartridges/CriticalImplantTrackerUiFragment.xaml.cs
+++ b/Content.Client/_WF/CartridgeLoader/Cartridges/CriticalImplantTrackerUiFragment.xaml.cs
@@ -91,6 +91,17 @@ public sealed partial class CriticalImplantTrackerUiFragment : BoxContainer
                 StyleClasses = { "LabelHeading" }
             };
             headerContainer.AddChild(nameLabel);
+
+            var inactiveLabel = new Label() // Wayfarer: Inactivity indicator for SSD characters
+            {
+                StyleClasses = { "LabelSubText" },
+                FontColorOverride = new Color(9, 169, 9),
+                Align = Label.AlignMode.Left,
+                Text = patient.IsSpaceSleepDisorder ? "Zzz" : "",
+                Margin = new Thickness(8, 0, 0, 0)
+            };
+            headerContainer.AddChild(inactiveLabel);
+
             patientContainer.AddChild(headerContainer);
 
             // Patient info (species and coordinates)

--- a/Content.Server/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
+++ b/Content.Server/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
@@ -62,9 +62,9 @@ public sealed class CrewManifestCartridgeSystem : EntitySystem
         if (owningStation is null)
             return;
 
-        var (stationName, entries) = _crewManifest.GetCrewManifest(owningStation.Value);
+        var entries = _crewManifest.GetCrewManifest(); // coyote: remove name
 
-        var state = new CrewManifestUiState(stationName, entries);
+        var state = new CrewManifestUiState(entries); // coyote: remove name
         _cartridgeLoader.UpdateCartridgeUiState(loaderUid, state);
     }
 

--- a/Content.Server/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
+++ b/Content.Server/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
@@ -63,9 +63,9 @@ public sealed class CrewManifestCartridgeSystem : EntitySystem
         // if (owningStation is null)
         //     return;
 
-        var entries = _crewManifest.GetCrewManifest(); // coyote: remove name
+        var entries = _crewManifest.GetCrewManifest(); // Coyote: remove name
 
-        var state = new CrewManifestUiState(entries); // coyote: remove name
+        var state = new CrewManifestUiState(entries); // Coyote: remove name
         _cartridgeLoader.UpdateCartridgeUiState(loaderUid, state);
     }
 

--- a/Content.Server/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
+++ b/Content.Server/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
@@ -57,10 +57,11 @@ public sealed class CrewManifestCartridgeSystem : EntitySystem
         if (!Resolve(uid, ref component))
             return;
 
-        var owningStation = _stationSystem.GetOwningStation(uid);
-
-        if (owningStation is null)
-            return;
+        // Coyote: make crew manifest global
+        // var owningStation = _stationSystem.GetOwningStation(uid);
+        //
+        // if (owningStation is null)
+        //     return;
 
         var entries = _crewManifest.GetCrewManifest(); // coyote: remove name
 

--- a/Content.Server/CrewManifest/CrewManifestEui.cs
+++ b/Content.Server/CrewManifest/CrewManifestEui.cs
@@ -27,10 +27,10 @@ public sealed class CrewManifestEui : BaseEui
         _crewManifest = crewManifestSystem;
     }
 
-    public override CrewManifestEuiState GetNewState()
+    public override CrewManifestEuiState GetNewState() // Coyote: Remove name
     {
-        var (name, entries) = _crewManifest.GetCrewManifest(_station);
-        return new(name, entries);
+        var entries = _crewManifest.GetCrewManifest();
+        return new(entries);
     }
 
     public override void Closed()

--- a/Content.Server/CrewManifest/CrewManifestSystem.cs
+++ b/Content.Server/CrewManifest/CrewManifestSystem.cs
@@ -3,7 +3,7 @@ using Content.Server.Access.Components; // Coyote
 using Content.Server.Access.Systems; // Coyote
 using Content.Server.Administration;
 using Content.Server.EUI;
-using Content.Server.Medical.SuitSensors; // Coyote
+using Content.Shared.Medical.SuitSensors; // Coyote
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
 using Content.Server.StationRecords;

--- a/Content.Server/CrewManifest/CrewManifestSystem.cs
+++ b/Content.Server/CrewManifest/CrewManifestSystem.cs
@@ -1,6 +1,10 @@
 using System.Linq;
+using Content.Server.Access.Components; // Coyote
+using Content.Server.Access.Systems; // Coyote
 using Content.Server.Administration;
 using Content.Server.EUI;
+using Content.Server.Medical.SuitSensors; // Coyote
+using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
 using Content.Server.StationRecords;
 using Content.Server.StationRecords.Systems;
@@ -10,6 +14,7 @@ using Content.Shared.CrewManifest;
 using Content.Shared.GameTicking;
 using Content.Shared.Roles;
 using Content.Shared.Station.Components;
+using Content.Shared.SSDIndicator; // Coyote
 using Content.Shared.StationRecords;
 using Robust.Shared.Configuration;
 using Robust.Shared.Console;
@@ -25,6 +30,7 @@ public sealed class CrewManifestSystem : EntitySystem
     [Dependency] private readonly EuiManager _euiManager = default!;
     [Dependency] private readonly IConfigurationManager _configManager = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly IdCardSystem _idCardSystem = default!; // Coyote
 
     /// <summary>
     ///     Cached crew manifest entries. The alternative is to outright
@@ -77,20 +83,20 @@ public sealed class CrewManifestSystem : EntitySystem
     // wrt the amount of players readied up.
     private void AfterGeneralRecordCreated(AfterGeneralRecordCreatedEvent ev)
     {
-        BuildCrewManifest(ev.Key.OriginStation);
-        UpdateEuis(ev.Key.OriginStation);
+        // BuildCrewManifest(); // coyote: NOP, we build on open
+        // UpdateEuis(ev.Key.OriginStation);
     }
 
     private void OnRecordModified(RecordModifiedEvent ev)
     {
-        BuildCrewManifest(ev.Key.OriginStation);
-        UpdateEuis(ev.Key.OriginStation);
+        // BuildCrewManifest(); // coyote: NOP, we build on open
+        // UpdateEuis(ev.Key.OriginStation);
     }
 
     private void OnRecordRemoved(RecordRemovedEvent ev)
     {
-        BuildCrewManifest(ev.Key.OriginStation);
-        UpdateEuis(ev.Key.OriginStation);
+        // BuildCrewManifest(); // coyote: NOP, we build on open
+        // UpdateEuis(ev.Key.OriginStation);
     }
 
     private void OnBoundUiClose(EntityUid uid, CrewManifestViewerComponent component, BoundUIClosedEvent ev)
@@ -110,12 +116,10 @@ public sealed class CrewManifestSystem : EntitySystem
     /// <summary>
     ///     Gets the crew manifest for a given station, along with the name of the station.
     /// </summary>
-    /// <param name="station">Entity uid of the station.</param>
     /// <returns>The name and crew manifest entries (unordered) of the station.</returns>
-    public (string name, CrewManifestEntries? entries) GetCrewManifest(EntityUid station)
+    public CrewManifestEntries GetCrewManifest() // coyote: remove args, remove name
     {
-        var valid = _cachedEntries.TryGetValue(station, out var manifest);
-        return (valid ? MetaData(station).EntityName : string.Empty, valid ? manifest : null);
+        return BuildCrewManifest(); // coyote
     }
 
     private void UpdateEuis(EntityUid station)
@@ -218,22 +222,40 @@ public sealed class CrewManifestSystem : EntitySystem
     /// <summary>
     ///     Builds the crew manifest for a station. Stores it in the cache afterwards.
     /// </summary>
-    /// <param name="station"></param>
-    private void BuildCrewManifest(EntityUid station)
+    private CrewManifestEntries BuildCrewManifest()
     {
-        var iter = _recordsSystem.GetRecordsOfType<GeneralStationRecord>(station);
+        var sensors = EntityQueryEnumerator<SuitSensorComponent>(); // Coyote
 
         var entries = new CrewManifestEntries();
-
         var entriesSort = new List<(JobPrototype? job, CrewManifestEntry entry)>();
-        foreach (var recordObject in iter)
-        {
-            var record = recordObject.Item2;
-            var entry = new CrewManifestEntry(record.Name, record.JobTitle, record.JobIcon, record.JobPrototype);
 
-            _prototypeManager.TryIndex(record.JobPrototype, out JobPrototype? job);
-            entriesSort.Add((job, entry));
-        }
+        while (sensors.MoveNext(out var uid, out var sensor)) // Coyote start
+        {
+            if (sensor.User == null ||
+                (TryComp<SSDIndicatorComponent>(sensor.User, out var indicator) && indicator.IsSSD))
+            {
+                continue;
+            }
+
+            var name = Loc.GetString("suit-sensor-component-unknown-name");
+            var jobTitle = Loc.GetString("suit-sensor-component-unknown-job");
+
+            if (!_idCardSystem.TryFindIdCard(sensor.User.Value, out var card))
+                continue;
+
+            if (card.Comp.FullName != null)
+                name = card.Comp.FullName;
+
+            if (card.Comp.LocalizedJobTitle != null)
+                jobTitle = card.Comp.LocalizedJobTitle;
+
+            if (!TryComp<PresetIdCardComponent>(card, out var preset))
+                continue;
+
+            var entry = new CrewManifestEntry(name, jobTitle, card.Comp.JobIcon, preset.JobName!.Value);
+
+            entriesSort.Add((null, entry));
+        } // Coyote end
 
         entriesSort.Sort((a, b) =>
         {
@@ -245,7 +267,8 @@ public sealed class CrewManifestSystem : EntitySystem
         });
 
         entries.Entries = entriesSort.Select(x => x.entry).ToArray();
-        _cachedEntries[station] = entries;
+        // _cachedEntries[station] = entries; // coyote: causes problems
+        return entries; // coyote
     }
 }
 

--- a/Content.Server/CrewManifest/CrewManifestSystem.cs
+++ b/Content.Server/CrewManifest/CrewManifestSystem.cs
@@ -4,7 +4,6 @@ using Content.Server.Access.Systems; // Coyote
 using Content.Server.Administration;
 using Content.Server.EUI;
 using Content.Shared.Medical.SuitSensors; // Coyote
-using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
 using Content.Server.StationRecords;
 using Content.Server.StationRecords.Systems;
@@ -15,7 +14,6 @@ using Content.Shared.GameTicking;
 using Content.Shared.Roles;
 using Content.Shared.Station.Components;
 using Content.Shared.SSDIndicator; // Coyote
-using Content.Shared.StationRecords;
 using Robust.Shared.Configuration;
 using Robust.Shared.Console;
 using Robust.Shared.Player;
@@ -83,20 +81,26 @@ public sealed class CrewManifestSystem : EntitySystem
     // wrt the amount of players readied up.
     private void AfterGeneralRecordCreated(AfterGeneralRecordCreatedEvent ev)
     {
-        // BuildCrewManifest(); // coyote: NOP, we build on open
+        // Coyote: NOP, we build on open
+        // BuildCrewManifest();
         // UpdateEuis(ev.Key.OriginStation);
+        // End Coyote
     }
 
     private void OnRecordModified(RecordModifiedEvent ev)
     {
-        // BuildCrewManifest(); // coyote: NOP, we build on open
+        // Coyote: NOP, we build on open
+        // BuildCrewManifest();
         // UpdateEuis(ev.Key.OriginStation);
+        // End Coyote
     }
 
     private void OnRecordRemoved(RecordRemovedEvent ev)
     {
-        // BuildCrewManifest(); // coyote: NOP, we build on open
+        // Coyote: NOP, we build on open
+        // BuildCrewManifest();
         // UpdateEuis(ev.Key.OriginStation);
+        // End Coyote
     }
 
     private void OnBoundUiClose(EntityUid uid, CrewManifestViewerComponent component, BoundUIClosedEvent ev)
@@ -117,9 +121,9 @@ public sealed class CrewManifestSystem : EntitySystem
     ///     Gets the crew manifest for a given station, along with the name of the station.
     /// </summary>
     /// <returns>The name and crew manifest entries (unordered) of the station.</returns>
-    public CrewManifestEntries GetCrewManifest() // coyote: remove args, remove name
+    public CrewManifestEntries GetCrewManifest() // Coyote: remove args, remove name
     {
-        return BuildCrewManifest(); // coyote
+        return BuildCrewManifest(); // Coyote
     }
 
     private void UpdateEuis(EntityUid station)
@@ -229,9 +233,10 @@ public sealed class CrewManifestSystem : EntitySystem
         var entries = new CrewManifestEntries();
         var entriesSort = new List<(JobPrototype? job, CrewManifestEntry entry)>();
 
-        while (sensors.MoveNext(out var uid, out var sensor)) // Coyote start
+        // Coyote start
+        while (sensors.MoveNext(out var uid, out var sensor))
         {
-            if (sensor.User == null ) // Wayfarer: Moved SSD check to allow showing SSD characters in a separate section
+            if (sensor.User == null) // Wayfarer: Moved SSD check to allow showing SSD characters in a separate section
             {
                 continue;
             }
@@ -259,7 +264,8 @@ public sealed class CrewManifestSystem : EntitySystem
             var entry = new CrewManifestEntry(name, jobTitle, card.Comp.JobIcon, jobName); // Wayfarer: preset.JobName!.Value < jobName
 
             entriesSort.Add((null, entry));
-        } // Coyote end
+        }
+        // End Coyote
 
         entriesSort.Sort((a, b) =>
         {
@@ -271,8 +277,8 @@ public sealed class CrewManifestSystem : EntitySystem
         });
 
         entries.Entries = entriesSort.Select(x => x.entry).ToArray();
-        // _cachedEntries[station] = entries; // coyote: causes problems
-        return entries; // coyote
+        // _cachedEntries[station] = entries; // Coyote: causes problems
+        return entries; // Coyote
     }
 }
 

--- a/Content.Server/CrewManifest/CrewManifestSystem.cs
+++ b/Content.Server/CrewManifest/CrewManifestSystem.cs
@@ -231,8 +231,7 @@ public sealed class CrewManifestSystem : EntitySystem
 
         while (sensors.MoveNext(out var uid, out var sensor)) // Coyote start
         {
-            if (sensor.User == null ||
-                (TryComp<SSDIndicatorComponent>(sensor.User, out var indicator) && indicator.IsSSD))
+            if (sensor.User == null ) // Wayfarer: Moved SSD check to allow showing SSD characters in a separate section
             {
                 continue;
             }
@@ -252,7 +251,12 @@ public sealed class CrewManifestSystem : EntitySystem
             if (!TryComp<PresetIdCardComponent>(card, out var preset))
                 continue;
 
-            var entry = new CrewManifestEntry(name, jobTitle, card.Comp.JobIcon, preset.JobName!.Value);
+            var jobName = preset.JobName!.Value; // Wayfarer
+            if (TryComp<SSDIndicatorComponent>(sensor.User, out var ssd) && ssd.IsSSD) // Wayfarer: Group SSD players separately
+                jobName = "Inactive";
+
+
+            var entry = new CrewManifestEntry(name, jobTitle, card.Comp.JobIcon, jobName); // Wayfarer: preset.JobName!.Value < jobName
 
             entriesSort.Add((null, entry));
         } // Coyote end

--- a/Content.Server/_WF/CartridgeLoader/Cartridges/CriticalImplantTrackerCartridgeSystem.cs
+++ b/Content.Server/_WF/CartridgeLoader/Cartridges/CriticalImplantTrackerCartridgeSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.PDA;
+using Content.Shared.SSDIndicator;
 using Content.Shared.Trigger.Components.Conditions;
 using Content.Shared.Trigger.Components.Triggers;
 using Robust.Shared.Containers;
@@ -143,8 +144,13 @@ public sealed class CriticalImplantTrackerCartridgeSystem : EntitySystem
             if (!hasActiveBeacon)
                 continue;
 
+            // Check if the character is SSD
+            var isSpaceSleepDisorder = false;
+            if (TryComp<SSDIndicatorComponent>(mobUid, out var indicator))
+                isSpaceSleepDisorder = indicator.IsSSD;
+
             // Add all critical/dead patients with active beacons
-            patients.Add(new CriticalPatientData(name, coordinates, species, timeSinceCrit, isDead));
+            patients.Add(new CriticalPatientData(name, coordinates, species, timeSinceCrit, isDead, isSpaceSleepDisorder));
         }
 
         var state = new CriticalImplantTrackerUiState(patients);

--- a/Content.Shared/CartridgeLoader/Cartridges/CrewManifestUiState.cs
+++ b/Content.Shared/CartridgeLoader/Cartridges/CrewManifestUiState.cs
@@ -6,12 +6,12 @@ namespace Content.Shared.CartridgeLoader.Cartridges;
 [Serializable, NetSerializable]
 public sealed class CrewManifestUiState : BoundUserInterfaceState
 {
-    public string StationName;
+    // public string StationName; // coyote: remove name
     public CrewManifestEntries? Entries;
 
-    public CrewManifestUiState(string stationName, CrewManifestEntries? entries)
+    public CrewManifestUiState(CrewManifestEntries? entries) // coyote: remove name
     {
-        StationName = stationName;
+        // StationName = stationName;  // coyote: remove name
         Entries = entries;
     }
 }

--- a/Content.Shared/CartridgeLoader/Cartridges/CrewManifestUiState.cs
+++ b/Content.Shared/CartridgeLoader/Cartridges/CrewManifestUiState.cs
@@ -6,12 +6,12 @@ namespace Content.Shared.CartridgeLoader.Cartridges;
 [Serializable, NetSerializable]
 public sealed class CrewManifestUiState : BoundUserInterfaceState
 {
-    // public string StationName; // coyote: remove name
+    // public string StationName; // Coyote: remove name
     public CrewManifestEntries? Entries;
 
-    public CrewManifestUiState(CrewManifestEntries? entries) // coyote: remove name
+    public CrewManifestUiState(CrewManifestEntries? entries) // Coyote: remove name
     {
-        // StationName = stationName;  // coyote: remove name
+        // StationName = stationName;  // Coyote: remove name
         Entries = entries;
     }
 }

--- a/Content.Shared/CrewManifest/SharedCrewManifestSystem.cs
+++ b/Content.Shared/CrewManifest/SharedCrewManifestSystem.cs
@@ -21,14 +21,12 @@ public sealed class RequestCrewManifestMessage : EntityEventArgs
 }
 
 [Serializable, NetSerializable]
-public sealed class CrewManifestEuiState : EuiStateBase
+public sealed class CrewManifestEuiState : EuiStateBase // Coyote: Removed StationName
 {
-    public string StationName { get; }
     public CrewManifestEntries? Entries { get; }
 
-    public CrewManifestEuiState(string stationName, CrewManifestEntries? entries)
+    public CrewManifestEuiState(CrewManifestEntries? entries)
     {
-        StationName = stationName;
         Entries = entries;
     }
 }

--- a/Content.Shared/CrewManifest/SharedCrewManifestSystem.cs
+++ b/Content.Shared/CrewManifest/SharedCrewManifestSystem.cs
@@ -25,7 +25,7 @@ public sealed class CrewManifestEuiState : EuiStateBase // Coyote: Removed Stati
 {
     public CrewManifestEntries? Entries { get; }
 
-    public CrewManifestEuiState(CrewManifestEntries? entries)
+    public CrewManifestEuiState(CrewManifestEntries? entries) // Coyote: Removed StationName
     {
         Entries = entries;
     }

--- a/Content.Shared/Medical/SuitSensors/SharedSuitSensor.cs
+++ b/Content.Shared/Medical/SuitSensors/SharedSuitSensor.cs
@@ -32,6 +32,7 @@ public sealed class SuitSensorStatus
     public NetCoordinates? Coordinates;
     public int? MapHash; // Frontier - Crew monitor map check
     public string LocationName; // Frontier
+    public bool IsSpaceSleepDisorder; // Wayfarer: Crew monitor SSD indicator
 }
 
 [Serializable, NetSerializable]
@@ -72,6 +73,7 @@ public static class SuitSensorConstants
     public const string NET_SUIT_SENSOR_UID = "uid";
     public const string NET_LOCATION_NAME = "location"; // Frontier
     public const string NET_MAP_HASH = "mapHash"; // Frontier - Crew monitor map check
+    public const string NET_IS_SSD = "ssd"; // Wayfarer
 
     ///Used by the CrewMonitoringServerSystem to send the status of all connected suit sensors to each crew monitor
     public const string NET_STATUS_COLLECTION = "suit-status-collection";

--- a/Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs
+++ b/Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs
@@ -447,8 +447,10 @@ public abstract class SharedSuitSensorSystem : EntitySystem
                 break;
         }
 
+        // Wayfarer: SSD indicator in crew monitor UI
         if (TryComp<SSDIndicatorComponent>(sensor.User.Value, out var indicatorComp))
             status.IsSpaceSleepDisorder = indicatorComp.IsSSD;
+        // End Wayfarer
 
         return status;
     }

--- a/Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs
+++ b/Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs
@@ -380,10 +380,6 @@ public abstract class SharedSuitSensorSystem : EntitySystem
         if (TryComp(sensor.User.Value, out MobStateComponent? mobState))
             isAlive = !_mobStateSystem.IsDead(sensor.User.Value, mobState);
 
-        // Coyote: Don't show SSD people on suit sensors.
-        if (TryComp<SSDIndicatorComponent>(sensor.User.Value, out var ssd) && ssd.IsSSD && isAlive)
-            return null;
-
         // get mob total damage
         var totalDamage = 0;
         if (TryComp<DamageableComponent>(sensor.User.Value, out var damageable))

--- a/Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs
+++ b/Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs
@@ -447,6 +447,9 @@ public abstract class SharedSuitSensorSystem : EntitySystem
                 break;
         }
 
+        if (TryComp<SSDIndicatorComponent>(sensor.User.Value, out var indicatorComp))
+            status.IsSpaceSleepDisorder = indicatorComp.IsSSD;
+
         return status;
     }
 
@@ -477,6 +480,8 @@ public abstract class SharedSuitSensorSystem : EntitySystem
             payload.Add(SuitSensorConstants.NET_MAP_HASH, status.MapHash); // Frontier
         if (status.LocationName != null) // Frontier
             payload.Add(SuitSensorConstants.NET_LOCATION_NAME, status.LocationName); // Frontier
+        if (status.IsSpaceSleepDisorder != null) // Wayfarer
+            payload.Add(SuitSensorConstants.NET_IS_SSD, status.IsSpaceSleepDisorder);
 
         return payload;
     }
@@ -501,6 +506,7 @@ public abstract class SharedSuitSensorSystem : EntitySystem
         if (!payload.TryGetValue(SuitSensorConstants.NET_SUIT_SENSOR_UID, out NetEntity suitSensorUid)) return null;
         if (!payload.TryGetValue(SuitSensorConstants.NET_OWNER_UID, out NetEntity ownerUid)) return null;
         if (!payload.TryGetValue(SuitSensorConstants.NET_LOCATION_NAME, out string? location)) return null; // Frontier
+        if (!payload.TryGetValue(SuitSensorConstants.NET_IS_SSD, out bool? isSpaceSleepDisorder)) return null; // Wayfarer
 
         // try get total damage and cords (optionals)
         payload.TryGetValue(SuitSensorConstants.NET_TOTAL_DAMAGE, out int? totalDamage);
@@ -515,6 +521,7 @@ public abstract class SharedSuitSensorSystem : EntitySystem
             TotalDamageThreshold = totalDamageThreshold,
             Coordinates = coords,
             MapHash = mapHash, // Frontier - Crew monitor map check
+            IsSpaceSleepDisorder = isSpaceSleepDisorder.Value, // Wayfarer
         };
         return status;
     }

--- a/Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs
+++ b/Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs
@@ -480,8 +480,7 @@ public abstract class SharedSuitSensorSystem : EntitySystem
             payload.Add(SuitSensorConstants.NET_MAP_HASH, status.MapHash); // Frontier
         if (status.LocationName != null) // Frontier
             payload.Add(SuitSensorConstants.NET_LOCATION_NAME, status.LocationName); // Frontier
-        if (status.IsSpaceSleepDisorder != null) // Wayfarer
-            payload.Add(SuitSensorConstants.NET_IS_SSD, status.IsSpaceSleepDisorder);
+        payload.Add(SuitSensorConstants.NET_IS_SSD, status.IsSpaceSleepDisorder); // Wayfarer
 
         return payload;
     }

--- a/Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs
+++ b/Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
+using Content.Shared.SSDIndicator; // Coyote
 using Content.Shared.Station;
 using Content.Shared.Verbs;
 using Robust.Shared.Containers;
@@ -378,6 +379,10 @@ public abstract class SharedSuitSensorSystem : EntitySystem
         var isAlive = false;
         if (TryComp(sensor.User.Value, out MobStateComponent? mobState))
             isAlive = !_mobStateSystem.IsDead(sensor.User.Value, mobState);
+
+        // Coyote: Don't show SSD people on suit sensors.
+        if (TryComp<SSDIndicatorComponent>(sensor.User.Value, out var ssd) && ssd.IsSSD && isAlive)
+            return null;
 
         // get mob total damage
         var totalDamage = 0;

--- a/Content.Shared/_WF/CartridgeLoader/Cartridges/CriticalImplantTrackerUiState.cs
+++ b/Content.Shared/_WF/CartridgeLoader/Cartridges/CriticalImplantTrackerUiState.cs
@@ -22,14 +22,16 @@ public sealed class CriticalPatientData
     public string Species { get; }
     public string TimeSinceCrit { get; }
     public bool IsDead { get; }
+    public bool IsSpaceSleepDisorder { get; }
 
-    public CriticalPatientData(string name, string coordinates, string species, string timeSinceCrit, bool isDead)
+    public CriticalPatientData(string name, string coordinates, string species, string timeSinceCrit, bool isDead, bool isSpaceSleepDisorder)
     {
         Name = name;
         Coordinates = coordinates;
         Species = species;
         TimeSinceCrit = timeSinceCrit;
         IsDead = isDead;
+        IsSpaceSleepDisorder = isSpaceSleepDisorder;
     }
 }
 

--- a/Resources/Locale/en-US/_WF/job/department.ftl
+++ b/Resources/Locale/en-US/_WF/job/department.ftl
@@ -1,0 +1,2 @@
+department-Inactive = Inactive
+department-inactive-description = Used by crew manifests to display crew that is currently experiencing the effects of Space Sleep Disorder.

--- a/Resources/Locale/en-US/_WF/job_names.ftl
+++ b/Resources/Locale/en-US/_WF/job_names.ftl
@@ -7,3 +7,6 @@ job-description-wayfarer =  Not committed to anything beyond their own survival,
 
 job-name-wayfarer-interview = Wayfarer Applicant
 job-description-wayfarer-interview =  Work underneath your new Captain as they guide you.
+
+job-name-inactive = Inactive
+job-description-inactive = Someone who is currently experiencing the effects of Space Sleep Disorder

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/Misc/identification_cards.yml
@@ -207,10 +207,10 @@
 - type: entity
   parent: PassengerIDCard
   id: ContractorIDCard
-  name: contractor ID card
+  name: wayfarer ID card # Wayfarer: contractor < wayfarer
   components:
   - type: PresetIdCard
-    job: Contractor
+    job: Wayfarer # Wayfarer: Contractor < Wayfarer
   - type: Sprite
     sprite: _NF/Objects/Misc/id_cards.rsi
     layers:

--- a/Resources/Prototypes/_WF/Roles/Jobs/Inactive/inactive.yml
+++ b/Resources/Prototypes/_WF/Roles/Jobs/Inactive/inactive.yml
@@ -1,0 +1,12 @@
+- type: job
+  id: Inactive
+  name: job-name-inactive
+  description: job-description-inactive
+  playTimeTracker: JobInactive
+  setPreference: false
+  icon: "JobIconUnknown"
+  supervisors: job-supervisors-hire
+  canBeAntag: false
+
+- type: playTimeTracker
+  id: JobInactive

--- a/Resources/Prototypes/_WF/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/_WF/Roles/Jobs/departments.yml
@@ -1,0 +1,8 @@
+- type: department # Added to group SSD players separately on crew manifest
+  id: InactiveDeparment
+  name: department-Inactive
+  description: department-inactive-description
+  color: "#808080"
+  weight: -100 # should be the last section in crew manifest
+  roles:
+  - Inactive

--- a/Resources/Prototypes/_WF/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/_WF/Roles/Jobs/departments.yml
@@ -4,5 +4,6 @@
   description: department-inactive-description
   color: "#808080"
   weight: -100 # should be the last section in crew manifest
+  editorHidden: true
   roles:
   - Inactive


### PR DESCRIPTION
## About the PR
- Ported global crew manifest from https://github.com/ARF-SS13/coyote-frontier/pull/993 db899888efce9e042b0260030939007839bac8ee
  - Made some changes to get it to work with our crew manifest, as Coyote's was organized differently. My changes related to this should all be contained within d9ba247b5eb4c15d18de9fe36c35ed19b2c40520
- Added SSD indicator to crew manifest UI d65fd15437510bea8a5a4c922259588bec8446ed
- Added SSD indicator to crew monitor UI 1294831e621350ac85e55e5c4d159129ec089f2e
- Added SSD indicator to crit implant tracker PDA cartridge cd364240b4e90756a925f6e2b8a877bf3bca37f2

## Why / Balance
Generally: Its useful to know who is around, or who might be coming back around before the shift is up
For medical: Its useful to know how much knocking you should do before you bust in to revive somebody

## Technical details
- For global crew manifest, see https://github.com/ARF-SS13/coyote-frontier/pull/993 in addition to the nested notes below
  - Coyote's `SuitSensorSystem` was in Content.Server, so the changes targeting that file were made in Content.Shared instead
  - `CrewManifestCartridgeSystem` had some station-specific code that hadn't been touched by the cherry-pick, commented this out
  - Crew manifest also was unable to show anyone in the Wayfarer job until I changed the IDPreset's job on `ContractorIDCard` to `Wayfarer`. I also changed the item's name to `wayfarer ID card`
- Crew manifest SSD indicator
  - Disabled the code that prevents SSD characters from being listed on crew manifest
  - When building the list of crew members to display on the manifest in (`Content.Server/CrewManifest/CrewManifestSystem.cs`), if a character is SSD the JobPrototype passed to the clientside will be `"Inactive"`
    - This allows SSD characters to be sorted into a separate category, and is what the SSD indicator ('Zzz') relies on, but required:
  - Added a new department `InactiveDepartment`, which is only used as a category in the crew manifest
- Crew monitor SSD indicator
  - When suit sensors are updated (`Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs` we check for the SSD component, and if present store the character's SSD status inside of the instance of SuitSensorStatus we're building
  - This required adding a new `SuitSensorConstant` & ensuring its passed in the suit sensor packet
- Crit implant SSD indicator
  - Added a new bool to `CriticalPatientData` called `IsSpaceSleepDisorder`
    - Set in `Content.Server/_WF/CartridgeLoader/Cartridges/CriticalImplantTrackerCartridgeSystem.cs`, assumed false if no `SSDIndicatorComponent` is found

In all SSD indicator implementations here, the label is always present, but only has text inside when the related character is SSD. Fixed widths are used in all cases except the crit implant PDA cartridge, to avoid alignment issues

## How to test
Build/Run
Respawn your character once, so you have a test dummy
With devtools, place a crew monitoring server & console, and a crit implant tracker cartridge
Shoot the SSD dummy until crit
Inspect all three user interfaces (Crew manifest, crit tracker, crew monitoring console)

## Media
<img width="1103" height="496" alt="image" src="https://github.com/user-attachments/assets/18d2994b-9c85-46ff-b7b3-5c64a14ddc26" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Please be scrutinizing in your review! In particular around the suit sensor packet stuff, I don't really know what I'm doing

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Crew manifest now shows if someone is SSD, grouping them in an 'Inactive' section at the bottom
- tweak: Crew monitoring console now shows if someone is SSD.
- tweak: Crit implant tracker now shows if someone is SSD.