### PR TITLE
Meteor swarm command

### DIFF
--- a/Content.Server/StationEvents/Components/MeteorSwarmComponent.cs
+++ b/Content.Server/StationEvents/Components/MeteorSwarmComponent.cs
@@ -55,4 +55,12 @@ public sealed partial class MeteorSwarmComponent : Component
 
     [DataField]
     public MinMax WaveCooldown = new (10, 60);
+
+    // Wayfarer: Optional admin-set target. If null, the meteors hit a random POI or active player ship.
+    [DataField]
+    public EntityUid? TargetGrid;
+
+    // Wayfarer: When true the meteor event starts with no announcement or sound. Set by the wfmeteorswarm command.
+    [DataField]
+    public bool Silent;
 }

--- a/Content.Server/StationEvents/Events/MeteorSwarmSystem.cs
+++ b/Content.Server/StationEvents/Events/MeteorSwarmSystem.cs
@@ -1,10 +1,12 @@
 using System.Numerics;
+using Content.Server._Coyote.ShuttleCrewStatus; // Wayfarer
 using Content.Server.Chat.Systems;
 using Content.Server.GameTicking.Rules;
 using Content.Server.Station.Systems;
 using Content.Server.StationEvents.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Random.Helpers;
+using Content.Server.Shuttles.Components; // Wayfarer
 using Robust.Server.Audio;
 using Robust.Shared.Map;
 using Robust.Shared.Physics.Components;
@@ -26,9 +28,18 @@ public sealed class MeteorSwarmSystem : GameRuleSystem<MeteorSwarmComponent>
         base.Added(uid, component, gameRule, args);
 
         component.WaveCounter = component.Waves.Next(RobustRandom);
+    }
+
+    // Wayfarer: Plays the meteor event's announcement and sound, unless it was silenced.
+    protected override void Started(EntityUid uid, MeteorSwarmComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+
+        if (component.Silent)
+            return;
 
         // we don't want to send to players who aren't in game (i.e. in the lobby)
-        Filter allPlayersInGame = Filter.Empty().AddWhere(GameTicker.UserHasJoinedGame);
+        var allPlayersInGame = Filter.Empty().AddWhere(GameTicker.UserHasJoinedGame);
 
         if (component.Announcement is { } locId)
             _chat.DispatchFilteredAnnouncement(allPlayersInGame, Loc.GetString(locId), playSound: false, colorOverride: Color.Gold);
@@ -43,12 +54,8 @@ public sealed class MeteorSwarmSystem : GameRuleSystem<MeteorSwarmComponent>
 
         component.NextWaveTime += TimeSpan.FromSeconds(component.WaveCooldown.Next(RobustRandom));
 
-
-        if (_station.GetStations().Count == 0)
-            return;
-
-        var station = RobustRandom.Pick(_station.GetStations());
-        if (_station.GetLargestGrid(station) is not { } grid)
+        // Wayfarer: Nothing to hit this wave, so skip it.
+        if (!TryPickTargetGrid(component, out var grid))
             return;
 
         var mapId = Transform(grid).MapID;
@@ -88,5 +95,62 @@ public sealed class MeteorSwarmSystem : GameRuleSystem<MeteorSwarmComponent>
         {
             ForceEndSelf(uid, gameRule);
         }
+    }
+
+    // Wayfarer: Sets which grid the meteors hit when targeted manually.
+    public void SetTargetGrid(EntityUid ruleEntity, EntityUid? targetGrid, MeteorSwarmComponent? component = null)
+    {
+        if (!Resolve(ruleEntity, ref component))
+            return;
+        component.TargetGrid = targetGrid;
+    }
+
+    // Wayfarer: Prevents the server announcement when a meteor event is called manually.
+    public void SetSilent(EntityUid ruleEntity, MeteorSwarmComponent? component = null)
+    {
+        if (!Resolve(ruleEntity, ref component))
+            return;
+        component.Silent = true;
+    }
+
+    // Wayfarer: Every grid a meteor swarm can hit. That is every POI and station, plus active player ships.
+    public IEnumerable<EntityUid> GetTargetableGrids()
+    {
+        var seen = new HashSet<EntityUid>();
+
+        foreach (var station in _station.GetStations())
+        {
+            if (_station.GetLargestGrid(station) is not { } grid)
+                continue;
+            if (TryComp<ShuttleCrewStatusComponent>(grid, out var crew) && !crew.HasActiveCrew)
+                continue;
+            if (seen.Add(grid))
+                yield return grid;
+        }
+
+        // Catch any active player ship the station loop above missed.
+        var ships = EntityQueryEnumerator<ShuttleCrewStatusComponent, ShuttleComponent>();
+        while (ships.MoveNext(out var ship, out var status, out _))
+            if (status.HasActiveCrew && seen.Add(ship))
+                yield return ship;
+    }
+
+    // Wayfarer: Picks the grid the meteors hit. The target if one was set, otherwise a random valid target.
+    private bool TryPickTargetGrid(MeteorSwarmComponent component, out EntityUid grid)
+    {
+        grid = default;
+
+        if (component.TargetGrid is { } pinned && Exists(pinned))
+        {
+            grid = pinned;
+            return true;
+        }
+
+        var pool = new List<EntityUid>(GetTargetableGrids());
+        if (pool.Count == 0)
+            return false;
+
+        grid = RobustRandom.Pick(pool);
+        return true;
     }
 }

--- a/Content.Server/_WF/Administration/Commands/MeteorSwarmCommand.cs
+++ b/Content.Server/_WF/Administration/Commands/MeteorSwarmCommand.cs
@@ -1,0 +1,123 @@
+﻿using System.Linq;
+using Content.Server.Administration;
+using Content.Server.GameTicking;
+using Content.Server.StationEvents.Events;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Server._WF.Administration.Commands;
+
+[AdminCommand(AdminFlags.Fun)]
+public sealed class MeteorSwarmCommand : LocalizedEntityCommands
+{
+    [Dependency] private readonly GameTicker _gameTicker = default!;
+    [Dependency] private readonly MeteorSwarmSystem _meteorSwarm = default!;
+
+    public override string Command => "wfmeteorswarm";
+    public override string Description => "Spawns a meteor swarm of the given severity. Optionally targets a specific grid by name.";
+    public override string Help => $"Usage: {Command} <severity> [target name or 'random']";
+
+    private static readonly Dictionary<string, string> SeverityToPrototype = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["SpaceDustMinor"] = "GameRuleSpaceDustMinor",
+        ["SpaceDustMajor"] = "GameRuleSpaceDustMajor",
+        ["MeteorSwarmSmall"] = "GameRuleMeteorSwarmSmall",
+        ["MeteorSwarmMedium"] = "GameRuleMeteorSwarmMedium",
+        ["MeteorSwarmLarge"] = "GameRuleMeteorSwarmLarge",
+        ["UristSwarm"] = "GameRuleUristSwarm",
+        ["ClownSwarm"] = "GameRuleClownSwarm",
+        ["CowSwarm"] = "GameRuleCowSwarm",
+        ["PotatoSwarm"] = "GameRulePotatoSwarm",
+        ["FunSwarm"] = "GameRuleFunSwarm",
+    };
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length < 1)
+        {
+            shell.WriteError(Help);
+            return;
+        }
+
+        if (!SeverityToPrototype.TryGetValue(args[0], out var prototypeId))
+        {
+            shell.WriteError($"Unknown severity '{args[0]}'. Valid: {string.Join(", ", SeverityToPrototype.Keys)}.");
+            return;
+        }
+
+        EntityUid? targetUid = null;
+        if (args.Length > 1 && !string.Equals(args[1], "random", StringComparison.OrdinalIgnoreCase))
+        {
+            var targetName = string.Join(' ', args.Skip(1)).Trim();
+            var candidates = FindGridsByName(targetName);
+
+            switch (candidates.Count)
+            {
+                case 0:
+                    shell.WriteError($"No POI or active player ship matches '{targetName}'.");
+                    return;
+                case > 1:
+                    var names = string.Join(", ", candidates.Select(c => $"\"{EntityManager.GetComponent<MetaDataComponent>(c).EntityName}\""));
+                    shell.WriteError($"Multiple matches for '{targetName}': {names}. Be more specific.");
+                    return;
+                default:
+                    targetUid = candidates[0];
+                    break;
+            }
+        }
+
+        var ruleEntity = _gameTicker.AddGameRule(prototypeId);
+        _meteorSwarm.SetSilent(ruleEntity);
+
+        if (targetUid is { } target)
+        {
+            _meteorSwarm.SetTargetGrid(ruleEntity, target);
+            var targetName = EntityManager.GetComponent<MetaDataComponent>(target).EntityName;
+            shell.WriteLine($"Meteor swarm '{args[0]}' targeting \"{targetName}\".");
+        }
+        else
+            shell.WriteLine($"Meteor swarm '{args[0]}' targeting random POI or active player ship.");
+
+        if (!_gameTicker.StartGameRule(ruleEntity))
+            shell.WriteError($"Failed to start game rule '{prototypeId}'.");
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+            return CompletionResult.FromHintOptions(SeverityToPrototype.Keys, "<severity>");
+
+        if (args.Length == 2)
+        {
+            var names = CollectTargetNames();
+            return CompletionResult.FromHintOptions(names.Prepend("random"), "<target name>");
+        }
+
+        return CompletionResult.Empty;
+    }
+
+    private List<EntityUid> FindGridsByName(string query)
+    {
+        var matches = new List<EntityUid>();
+        foreach (var grid in _meteorSwarm.GetTargetableGrids())
+        {
+            var name = EntityManager.GetComponent<MetaDataComponent>(grid).EntityName;
+            if (name.Equals(query, StringComparison.OrdinalIgnoreCase))
+                return [grid];
+
+            if (name.Contains(query, StringComparison.OrdinalIgnoreCase))
+                matches.Add(grid);
+        }
+        return matches;
+    }
+
+    private IEnumerable<string> CollectTargetNames()
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var grid in _meteorSwarm.GetTargetableGrids())
+        {
+            names.Add(EntityManager.GetComponent<MetaDataComponent>(grid).EntityName);
+        }
+        return names;
+    }
+}

--- a/Resources/IgnoredPrototypes/ignoredPrototypes.yml
+++ b/Resources/IgnoredPrototypes/ignoredPrototypes.yml
@@ -17,14 +17,26 @@
  - /Prototypes/Entities/Objects/Weapons/Guns/Battery
  - /Prototypes/Entities/Objects/Weapons/Guns/HMGs
  - /Prototypes/Entities/Objects/Weapons/Guns/Pistols
- - /Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+ # - /Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml # Wayfarer: Removed so the meteor swarm command can spawn meteors
  - /Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
  - /Prototypes/Entities/Objects/Weapons/Guns/Revolvers
  - /Prototypes/Entities/Objects/Weapons/Guns/Rifles
  - /Prototypes/Entities/Objects/Weapons/Guns/Shotguns
  - /Prototypes/Entities/Objects/Weapons/Guns/SMGs
  - /Prototypes/Entities/Objects/Weapons/Guns/Snipers
- - /Prototypes/GameRules # Too many issues with the things in this directory.
+ # - /Prototypes/GameRules # Too many issues with the things in this directory. # Wayfarer
+ # Wayfarer: Listed each file instead of GameRules so meteorswarms.yml still works for the meteor swarm command
+ - /Prototypes/GameRules/cargo_gifts.yml
+ - /Prototypes/GameRules/dynamic_rules.yml
+ - /Prototypes/GameRules/events.yml
+ - /Prototypes/GameRules/pests.yml
+ - /Prototypes/GameRules/random_sentience.yml
+ - /Prototypes/GameRules/roundstart.yml
+ - /Prototypes/GameRules/subgamemodes.yml
+ - /Prototypes/GameRules/survivor.yml
+ - /Prototypes/GameRules/unknown_shuttles.yml
+ - /Prototypes/GameRules/variation.yml
+ # End Wayfarer
  - /Prototypes/Procedural/Themes
  - /Prototypes/Procedural/vgroid.yml
  - /Prototypes/Procedural/salvage_loot.yml

--- a/Resources/Prototypes/GameRules/!FRONTIER_IGNORED.txt
+++ b/Resources/Prototypes/GameRules/!FRONTIER_IGNORED.txt
@@ -1,5 +1,0 @@
-Note: All files in here are ignored.
-
-If you change Resources/IgnoredPrototypes/ignoredPrototypes.yml, please remove this file as appropriate.
-
-Thank you.

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -116,8 +116,9 @@
     announcement: null
     announcementSound: null
     nonDirectional: true
-    meteors: {} # Frontier
-      # MeteorSpaceDust: 1 # Frontier
+    # Wayfarer: Restored upstream meteor events.
+    meteors:
+      MeteorSpaceDust: 1
     waves:
       min: 2
       max: 3
@@ -136,8 +137,9 @@
     announcement: station-event-space-dust-start-announcement
     announcementSound: /Audio/Announcements/attention.ogg
     nonDirectional: true
-    meteors: {} # Frontier
-      # MeteorSpaceDust: 1 # Frontier
+    # Wayfarer: Restored upstream meteor events.
+    meteors:
+      MeteorSpaceDust: 1
     waves:
       min: 2
       max: 3
@@ -153,9 +155,10 @@
     weight: 18
     minimumPlayers: 15
   - type: MeteorSwarm
-    meteors: {} # Frontier
-      # MeteorSmall: 7 # Frontier
-      # MeteorMedium: 3 # Frontier
+    # Wayfarer: Restored upstream meteor events.
+    meteors:
+      MeteorSmall: 7
+      MeteorMedium: 3
 
 - type: entity
   parent: GameRuleMeteorSwarm
@@ -164,10 +167,11 @@
   - type: StationEvent
     weight: 10
   - type: MeteorSwarm
-    meteors: {} # Frontier
-      # MeteorSmall: 3 # Frontier
-      # MeteorMedium: 6 # Frontier
-      # MeteorLarge: 1 # Frontier
+    # Wayfarer: Restored upstream meteor events.
+    meteors:
+      MeteorSmall: 3
+      MeteorMedium: 6
+      MeteorLarge: 1
 
 - type: entity
   parent: GameRuleMeteorSwarm
@@ -176,10 +180,11 @@
   - type: StationEvent
     weight: 5
   - type: MeteorSwarm
-    meteors: {} # Frontier
-      # MeteorSmall: 2 # Frontier
-      # MeteorMedium: 4 # Frontier
-      # MeteorLarge: 4 # Frontier
+    # Wayfarer: Restored upstream meteor events.
+    meteors:
+      MeteorSmall: 2
+      MeteorMedium: 4
+      MeteorLarge: 4
 
 - type: entity
   parent: GameRuleMeteorSwarm
@@ -190,8 +195,9 @@
   - type: MeteorSwarm
     announcement: station-event-meteor-urist-start-announcement
     announcementSound: /Audio/Announcements/attention.ogg
-    meteors: {} # Frontier
-      # MeteorUrist: 1 # Frontier
+    # Wayfarer: Restored upstream meteor events.
+    meteors:
+      MeteorUrist: 1
     waves:
       min: 3
       max: 3


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
This PR restores the meteor swarm events and creates a command wfmeteorswarm.

The wfmeteorswarm command is followed by the type of event to summon, followed optionally by a POI or Ship.

If no target is selected, it chooses a POI or active player ship as a target.

The wfmeteorswarm command also silences the station announcement.

**Disclosure:** This PR was made with the assistance of AI.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Was requested.

## Technical details
<!-- Summary of code changes for easier review. -->
 - **Content.Server/_WF/Administration/Commands/MeteorSwarmCommand.cs** — The wfmeteorswarm command, as described above.
  - **Content.Server/StationEvents/Events/MeteorSwarmSystem.cs** — Added GetTargetableGrids() (every POI and station, plus active player ships, with inactive player ships excluded). TryPickTargetGrid picks from it.
  - **Content.Server/StationEvents/Components/MeteorSwarmComponent.cs** — Added TargetGrid and Silent (suppresses announcement and sound) data fields.
  - **Resources/Prototypes/GameRules/meteorswarms.yml** — Restored the upstream meteor code Frontier had commented out.
  - **Resources/IgnoredPrototypes/ignoredPrototypes.yml** — Unignored meteors.yml, and replaced the GameRules ignore with per file entries so meteorswarms.yml loads while everything else stays disabled.
  - **Resources/Prototypes/GameRules/!FRONTIER_IGNORED.txt** - Deleted, as the file suggests to do.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Use the command to target specific POIs, or random targets, and ensure inactive player ships are not targeted.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: (Miles) Meteor swarm event command.
