### PR TITLE
Damage Cap Component and System

### DIFF
--- a/Content.Shared/_WF/Damage/DamageCapComponent.cs
+++ b/Content.Shared/_WF/Damage/DamageCapComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._WF.Damage;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class DamageCapComponent : Component
+{
+    /// <summary>
+    /// Maximum allowed damage for all damage types. (Yes, this is generalized. Fight me.)
+    /// </summary>
+    [DataField]
+    public int DamageCap = 3500;
+}

--- a/Content.Shared/_WF/Damage/DamageCapComponent.cs
+++ b/Content.Shared/_WF/Damage/DamageCapComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Shared._WF.Damage;
 public sealed partial class DamageCapComponent : Component
 {
     /// <summary>
-    /// Maximum allowed damage for all damage types. (Yes, this is generalized. Fight me.)
+    /// Maximum allowed damage for all damage types. (Yes, this is generalized. Fight me.) A cap of 3000 means you can have, for example, 3000 burn, 3000 brute, 3000 slash, so 3000 in any type.
     /// </summary>
     [DataField]
     public int DamageCap = 3500;

--- a/Content.Shared/_WF/Damage/DamageCapSystem.cs
+++ b/Content.Shared/_WF/Damage/DamageCapSystem.cs
@@ -1,0 +1,44 @@
+using Content.Shared.Damage;
+
+namespace Content.Shared._WF.Damage;
+
+public sealed class DamageCapSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<DamageCapComponent, BeforeDamageChangedEvent>(OnBeforeDamageChanged);
+    }
+
+    private void OnBeforeDamageChanged(Entity<DamageCapComponent> ent, ref BeforeDamageChangedEvent args)
+    {
+        var cap = ent.Comp.DamageCap;
+        if (cap <= 0)
+            return;
+
+        if (!TryComp<DamageableComponent>(ent.Owner, out var damageable))
+            return;
+
+        var currentDamage = damageable.Damage.DamageDict;
+        var delta = args.Damage;
+
+        foreach (var (typeId, addAmount) in delta.DamageDict)
+        {
+            if (addAmount <= 0)
+                continue; // probably needed in case of healing?
+
+            var current = currentDamage.GetValueOrDefault(typeId);
+            var roomLeft = cap - current;
+            if (roomLeft <= 0)
+            {
+                // Already at or above cap
+                delta.DamageDict.Remove(typeId);
+            }
+            else if (addAmount > roomLeft)
+            {
+                // Clamp it
+                delta.DamageDict[typeId] = roomLeft;
+            }
+        }
+    }
+}

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -222,6 +222,7 @@
     - DoorBumpOpener
     - AnomalyHost
   - type: ModifyUndies  # FLOOF Add
+  - type: DamageCap # Wayfarer
 
 - type: entity
   save: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
A simple component added to BaseMobSpecies that prevents any kind of damage over the specified cap. (Currently 3.5k)

How does it work?
Simple. Any damage type is capped to the specified max. For example, let's assume you set a damage cap of 300 for a simple Urist. If you throngle it, this is what happens:
<img width="266" height="446" alt="image" src="https://github.com/user-attachments/assets/17684fdd-44f1-4aca-823b-ae73c53d6c26" />

Every individual type of damage is capped to that amount. NOT the full amount, NOR each major type.

## Why / Balance
This was... Surprisingly requested, but I have not tested it much yet. I've throngled things at a lower cap, irradiated things at a higher cap, but not much after that. There's... Probably a better way to do this, but this is at least modular and I covered some edge cases. 

Untested as of yet: Medical pods, rotting (Already has its own component to take care of that, does it not?) and cellular.

**Feel free to tell me that I am bad and that I should feel bad if there's something egregious here.**

<img width="334" height="207" alt="image" src="https://github.com/user-attachments/assets/01059f43-e601-4030-ab5f-02b7286b4419" />

## Technical details
A component and a system.

## How to test
Set the damage cap to something lower like 500 to save yourself the trouble of time, irradiate, burn, slash away at urists and see that the damage doesn't exceed a certain threshold.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Damage cap system. All races -should- have this by default.
