### PR TITLE
Add capability to disable carrying, add carrying to all mobs

### DIFF
--- a/Content.Server/_EE/Carrying/CarriableComponent.cs
+++ b/Content.Server/_EE/Carrying/CarriableComponent.cs
@@ -36,5 +36,10 @@ namespace Content.Server.Carrying
         [DataField]
         public float MaxPickupDuration = 6.0f;
         // End Frontier
+
+        // Wayfarer, adds ability to disable the component
+        [DataField]
+        public bool CanPickup = true;
+
     }
 }

--- a/Content.Server/_EE/Carrying/CarryingSystem.cs
+++ b/Content.Server/_EE/Carrying/CarryingSystem.cs
@@ -89,6 +89,10 @@ namespace Content.Server.Carrying
                 || args.User == args.Target)
                 return;
 
+            // Wayfarer, adds ability to disable pickup
+            if (TryComp<CarriableComponent>(args.Target, out var carriable) && !carriable.CanPickup)
+                return;
+
             AlternativeVerb verb = new()
             {
                 Act = () =>

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -8,6 +8,7 @@
   suffix: AI
   abstract: true
   components:
+  - type: Carriable # Wayfarer, makes all mobs carriable. Weight still applies.
   - type: Reactive
     groups:
       Flammable: [Touch]

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -9,6 +9,7 @@
   id: BaseMobSpecies
   abstract: true
   components:
+  - type: Carriable # Wayfarer, makes all mobs carriable. Weight still applies.
   - type: Sprite
     layers:
     - map: [ "enum.HumanoidVisualLayers.TailBehind" ]

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -4,6 +4,19 @@
   parent: [BaseMob, MobDamageable, MobCombat, MobAtmosExposed, MobFlammable]
   abstract: true
   components:
+    - type: Carriable # This is needed due to the unique base
+      canPickup: false
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape:
+            !type:PhysShapeCircle
+            radius: 0.35
+          density: 185
+          mask:
+          - MobMask
+          layer:
+          - MobLayer
     - type: ContentEye
     - type: CameraRecoil
     - type: Reactive
@@ -294,7 +307,6 @@
       priority: 1
       lightningExplode: false
     - type: ComplexInteraction
-    - type: Carriable
     - type: Crawler
     - type: InteractionVerbs
       allowedVerbs:

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -4,7 +4,8 @@
   parent: [BaseMob, MobDamageable, MobCombat, MobAtmosExposed, MobFlammable]
   abstract: true
   components:
-    - type: Carriable # This is needed due to the unique base
+# Wayfarer: This is needed due to the unique base
+    - type: Carriable
       canPickup: false
     - type: Fixtures
       fixtures:

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -18,6 +18,7 @@
           - MobMask
           layer:
           - MobLayer
+# End Wayfarer
     - type: ContentEye
     - type: CameraRecoil
     - type: Reactive


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- carrying is influenced by weight: modify density of mobs that should be heavy rather than disabling it, ideally
    - If for example you have a mob that should not be able to be picked up under any circumstances, for example a mob bolted to the floor or something, you'd add `canPickup: false` to `Carriable` component
- all ported mobs will be carriable: the component does not need to be added to any new/existing mobs that may not have it ported from other forks
- Most if not all mobs can have carriable removed from their YML, unless they do not have a parent that has the component
- This should really be an upstream fix and cleanup but I'm not gonna be the one to do it
- Synthetic humanoids now have a defined density rather than the default 50. They are now the same weight as humans (this can be changed)

## Technical details
<!-- Summary of code changes for easier review. -->
- Adds a datafield so you can disable the ability for a mob to be picked up entirely.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
- Carry verb will appear on all mobs that do not have it disabled.
- I tested some xenos, humans can only carry runners, but stronger species (oni, diona) can carry burrowers and drones, but not praetorians

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [ N/A] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [N/A] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
- Any mob that probably shouldnt be carried needs to have their density modified to compensate

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Whisper
- add: All mobs should be carriable, but their weights will still apply.
- tweak: Synthetics (IPCs) now weigh the same as humans (heavier).
