### PR TITLE
Makes the POI BountyVend Inventory Infinite

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/bountyvend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/bountyvend.yml
@@ -108,22 +108,22 @@
     ClothingEyesGlassesMercenary: 4294967295 # Infinite
     ClothingUniformJumpsuitMercenary: 4294967295 # Infinite
     ClothingUniformJumpskirtMercenary: 4294967295 # Infinite
-    ClothingOuterVestWebMercenary: 3
+    ClothingOuterVestWebMercenary: 4294967295 # Wayfarer: 3<Infinite
     ClothingOuterEVASuitMercenary: 4294967295 # Infinite
     ClothingBeltMercenaryWebbing: 4294967295 # Infinite
     ClothingShoesBootsMercenary: 4294967295 # Infinite
     ClothingOuterBioArmoredMercenary: 4294967295 # Infinite
     ClothingHeadHatHoodBioArmoredMercenray: 4294967295 # Infinite
-    ClothingBackpackMercenary: 3
-    ClothingBackpackDuffelMercenary: 3
-    ClothingBackpackSatchelMercenary: 3
-    ClothingBackpackMessengerMercenary: 3
+    ClothingBackpackMercenary: 4294967295 # Wayfarer: 3<Infinite
+    ClothingBackpackDuffelMercenary: 4294967295 # Wayfarer: 3<Infinite
+    ClothingBackpackSatchelMercenary: 4294967295 # Wayfarer: 3<Infinite
+    ClothingBackpackMessengerMercenary: 4294967295 # Wayfarer: 3<Infinite
 # Private Security
     ClothingHeadHatBeretSecurity: 4294967295 # Infinite
     ClothingEyesGlassesSunglasses: 4294967295 # Infinite
     ClothingUniformJumpsuitPrivateSec: 4294967295 # Infinite
     ClothingUniformJumpskirtPrivateSec: 4294967295 # Infinite
-    ClothingOuterVestWebMercenaryBlack: 3
+    ClothingOuterVestWebMercenaryBlack: 4294967295 # Wayfarer: 3<Infinite
     ClothingOuterEVASuitPrivateSec: 4294967295 # Infinite
     ClothingBeltSecurity: 4294967295 # Infinite
     ClothingBeltMilitaryWebbing: 4294967295 # Infinite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
As the title says, some items had a limited inventory, which is not exactly normal save for hacked inventories.

## Why / Balance
Because POI machines generally have infinite inventory.

## Technical details
yml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Corrected the POI bounty vend inventory to have infinite stock of certain items.