### PR TITLE
Bandaid: Solar tracking on init.

### DIFF
--- a/Content.Server/_NF/Solar/Components/SolarPoweredGridComponent.cs
+++ b/Content.Server/_NF/Solar/Components/SolarPoweredGridComponent.cs
@@ -37,7 +37,7 @@ public sealed partial class SolarPoweredGridComponent : Component
     /// Useful to keep POIs running where players might not touch the solars.
     /// </summary>
     [DataField]
-    public bool TrackOnInit;
+    public bool TrackOnInit = true; // Wayfarer: Set to true
 
     /// <summary>
     /// If true, this component will not be culled.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Sets all solarpoweredgrid components to track on initialization.

## Why / Balance
While we don't have a system to properly track the sun (solar trackers don't work, they are purely decorative btw) this is a bandaid fix until a bridge is made between the trackers and the consoles, making any ship with a solar controller auto-track.

Revert this when we do.

## Media

Yup, all grids with solars and a control computer seem to auto-track on init. Good.
<img width="273" height="421" alt="image" src="https://github.com/user-attachments/assets/dc24ae66-3cac-4d3b-b554-6884bf675515" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Solars auto-track on start now. This is a temporary bandaid.