### PR TITLE
Shift Time Remaining API endpoint

### DIFF
--- a/Content.Server/ServerInfo/CharactersInfoManager.cs
+++ b/Content.Server/ServerInfo/CharactersInfoManager.cs
@@ -1,14 +1,19 @@
+using System;
 using System.Linq;
 using System.Net;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Content.Server.Database;
+using Content.Server.GameTicking;
+using Content.Shared.GameTicking;
 using Content.Server.Preferences.Managers;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Preferences;
 using Robust.Server.Player;
 using Robust.Server.ServerStatus;
+using Robust.Shared.Asynchronous;
 using Robust.Shared.Player;
+using Robust.Shared.Timing;
 
 namespace Content.Server.ServerInfo;
 
@@ -22,10 +27,13 @@ public sealed class CharactersInfoManager
     [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly IServerPreferencesManager _prefsManager = default!;
     [Dependency] private readonly IServerDbManager _db = default!;
+    [Dependency] private readonly ITaskManager _taskManager = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     public void Initialize()
     {
         _statusHost.AddHandler(HandleCharactersRequest);
+        _statusHost.AddHandler(HandleShiftTimeRemainingRequest);
     }
 
     private async Task<bool> HandleCharactersRequest(IStatusHandlerContext context)
@@ -89,5 +97,71 @@ public sealed class CharactersInfoManager
 
         await context.RespondAsync(jObject.ToJsonString(), HttpStatusCode.OK, "application/json");
         return true;
+    }
+
+    private async Task<bool> HandleShiftTimeRemainingRequest(IStatusHandlerContext context)
+    {
+        if (!context.IsGetLike || context.Url.AbsolutePath != "/shift-time-remaining")
+        {
+            return false;
+        }
+
+        var responseData = await RunOnMainThread(() =>
+        {
+            var ticker = _entityManager.System<GameTicker>();
+
+            var hasShiftEndTime = ticker.RunLevel == GameRunLevel.InRound && ticker.ShiftEndTime.HasValue;
+            var timeRemaining = TimeSpan.Zero;
+            DateTime? shiftEndTimeUtc = null;
+
+            if (hasShiftEndTime)
+            {
+                var remaining = ticker.ShiftEndTime!.Value - _timing.RealTime;
+                if (remaining > TimeSpan.Zero)
+                {
+                    timeRemaining = remaining;
+                    shiftEndTimeUtc = DateTime.UtcNow + remaining;
+                }
+                else
+                {
+                    shiftEndTimeUtc = DateTime.UtcNow;
+                }
+            }
+
+            return (hasShiftEndTime, timeRemaining, shiftEndTimeUtc);
+        });
+
+        var jObject = new JsonObject
+        {
+            ["hasShiftEndTime"] = responseData.hasShiftEndTime,
+            ["timeRemainingSeconds"] = (int) Math.Ceiling(responseData.timeRemaining.TotalSeconds),
+            ["shiftEndTimeUtc"] = responseData.shiftEndTimeUtc?.ToString("o")
+        };
+
+        context.ResponseHeaders["Content-Type"] = "application/json";
+        context.ResponseHeaders["Access-Control-Allow-Origin"] = "*";
+        context.ResponseHeaders["Access-Control-Allow-Methods"] = "GET, OPTIONS";
+        context.ResponseHeaders["Access-Control-Allow-Headers"] = "Content-Type";
+
+        await context.RespondAsync(jObject.ToJsonString(), HttpStatusCode.OK, "application/json");
+        return true;
+    }
+
+    private async Task<T> RunOnMainThread<T>(Func<T> func)
+    {
+        var taskCompletionSource = new TaskCompletionSource<T>();
+        _taskManager.RunOnMainThread(() =>
+        {
+            try
+            {
+                taskCompletionSource.TrySetResult(func());
+            }
+            catch (Exception e)
+            {
+                taskCompletionSource.TrySetException(e);
+            }
+        });
+
+        return await taskCompletionSource.Task;
     }
 }

--- a/Content.Server/ServerInfo/CharactersInfoManager.cs
+++ b/Content.Server/ServerInfo/CharactersInfoManager.cs
@@ -33,7 +33,9 @@ public sealed class CharactersInfoManager
     public void Initialize()
     {
         _statusHost.AddHandler(HandleCharactersRequest);
+        // Wayfarer
         _statusHost.AddHandler(HandleShiftTimeRemainingRequest);
+        // End Wayfarer
     }
 
     private async Task<bool> HandleCharactersRequest(IStatusHandlerContext context)
@@ -99,6 +101,7 @@ public sealed class CharactersInfoManager
         return true;
     }
 
+    // Wayfarer
     private async Task<bool> HandleShiftTimeRemainingRequest(IStatusHandlerContext context)
     {
         if (!context.IsGetLike || context.Url.AbsolutePath != "/shift-time-remaining")
@@ -146,6 +149,7 @@ public sealed class CharactersInfoManager
         await context.RespondAsync(jObject.ToJsonString(), HttpStatusCode.OK, "application/json");
         return true;
     }
+    // End Wayfarer
 
     private async Task<T> RunOnMainThread<T>(Func<T> func)
     {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Implemented a new public GET endpoint for shift time remaining.

Example return payload from dev:
```json
{
    "hasShiftEndTime": true,
    "timeRemainingSeconds": 259165,
    "shiftEndTimeUtc": "2026-05-28T23:28:29.7932844Z"
}
```

## Media
<img width="1180" height="263" alt="image" src="https://github.com/user-attachments/assets/3c24e8af-d1ad-4642-89da-e3d2a1021779" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [ ] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
_Changelog not needed_