### PR TITLE
Properly comments some WF changes done to ID localization, fixes a naming misconception.

### DIFF
--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -46,25 +46,26 @@ public sealed partial class IdCardConsoleComponent : Component
         //"Atmospherics",
         //"Bar",
         "Captain",
-        "Brig", //Moved to be where CGP would be on Alphabetical
+        "Brig", // Wayfarer: Moved to be where CGP would be on Alphabetical
         //"Cargo",
         //"Chapel",
         //"Chemistry",
         //"ChiefMedicalOfficer",
         "Command",
-        "HeadOfSecurity", // WF "Commodore"
-        "Brigmedic", // WF "Corpsman"
+        "HeadOfSecurity", // Frontier: moved down, alphabetic w.r.t. "Sheriff" // Wayfarer: Moved up. "Commodore"
+        "Brigmedic", // Frontier // Wayfarer: Moved down. "Corpsman"
         //"Cryogenics",
         "Engineering",
         "External",
+        "Frontier", // Frontier
         //"Hydroponics",
-        "Detective", // Wayfarer "Internal Affairs"
+        "Detective", // Frontier: moved into alphabetical order // Wayfarer: Moved down. "Internal Affairs"
         "Janitor",
         //"Kitchen",
         //"Lawyer",
         "Mail", // Frontier
         "Maintenance",
-        "Bailiff", // WF "Master at Arms"
+        "Bailiff", // Frontier // Wayfarer: Moved down. "Master at Arms"
         "Medical",
         "Mercenary", // Frontier
         "ChiefEngineer", // Frontier: moved down, alphabetic w.r.t. "Plant Manager"
@@ -73,11 +74,10 @@ public sealed partial class IdCardConsoleComponent : Component
         //"ResearchDirector",
         //"Salvage",
         "Security",
-        "Sergeant", // WF "Senior Peacekeeper"
+        "Sergeant", // Frontier
         "Service",
         "HeadOfPersonnel", // Frontier: moved down, alphabetic w.r.t. "Station Representative"
         "StationTrafficController", // Frontier
-        "Frontier", // Wayfarer
         //"Theatre",
     };
 

--- a/Resources/Locale/en-US/_NF/prototypes/access/accesses.ftl
+++ b/Resources/Locale/en-US/_NF/prototypes/access/accesses.ftl
@@ -1,4 +1,4 @@
-id-card-access-level-frontier = Wayfarer
+id-card-access-level-frontier = Frontier Staff
 id-card-access-level-pilot = Pilot
 id-card-access-level-mail = Mail
 id-card-access-level-mercenary = Mercenary

--- a/Resources/Locale/en-US/_NF/prototypes/access/accesses.ftl
+++ b/Resources/Locale/en-US/_NF/prototypes/access/accesses.ftl
@@ -1,4 +1,4 @@
-id-card-access-level-frontier = Frontier Staff
+id-card-access-level-frontier = Frontier
 id-card-access-level-pilot = Pilot
 id-card-access-level-mail = Mail
 id-card-access-level-mercenary = Mercenary

--- a/Resources/Locale/en-US/_NF/prototypes/access/accesses.ftl
+++ b/Resources/Locale/en-US/_NF/prototypes/access/accesses.ftl
@@ -1,4 +1,4 @@
-id-card-access-level-frontier = Frontier
+id-card-access-level-frontier = Frontier Staff
 id-card-access-level-pilot = Pilot
 id-card-access-level-mail = Mail
 id-card-access-level-mercenary = Mercenary


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
As title says, some of these were not commented properly in https://github.com/project-wayfarer/wayfarer-14/pull/280

Furthermore, Frontier access is a staff access, not general wayfarer access. It is given to Valets, Mail Carriers, STC, etc...

## Why / Balance
Because.

## Technical details
Mostly yml, some C for the sake of commenting.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No player facing changes.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
