### PR TITLE
Fix: NavInterfaceState FTL Exceptions

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -435,6 +435,9 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
             return new NavInterfaceState(SharedRadarConsoleSystem.DefaultMaxRange, GetNetCoordinates(coordinates), angle, docks, InertiaDampeningMode.Dampen, ServiceFlags.None, null, NetEntity.Invalid, true); // Frontier: add inertial dampening, target
 
         var autopilotState = WfGetAutopilotState(entity); // Wayfarer
+        var target = TryGetNetEntity(entity.Comp1.TargetEntity, out var targetEntity)
+            ? targetEntity.Value
+            : NetEntity.Invalid;
 
         return new NavInterfaceState(
             entity.Comp1.MaxRange,
@@ -444,7 +447,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
             _shuttle.NfGetInertiaDampeningMode(entity), // Frontier
             _shuttle.NfGetServiceFlags(entity), // Frontier
             entity.Comp1.Target, // Frontier
-            GetNetEntity(entity.Comp1.TargetEntity), // Frontier
+            target, // Frontier
             entity.Comp1.HideTarget, // Frontier
             autopilotState.Enabled, // Wayfarer
             autopilotState.HasServer); // Wayfarer


### PR DESCRIPTION
This PR fixes a shuttle console issue caused by resolving a net entity for a stale/deleted radar target during undock/FTL updates.

In ShuttleConsoleSystem.cs, GetNavState now uses a safe TryGetNetEntity lookup for TargetEntity and falls back to NetEntity.Invalid when metadata is missing, instead of forcing resolution and logging resolve errors.

## Technical details
- Prevents runtime resolve spam for missing MetaDataComponent on deleted entities
- Keeps shuttle nav UI/state updates stable during rapid docking/FTL transitions

## Testing
1. Run server in release build. 
2. Ride a bus for a bit.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
_No changelog needed_
