### PR TITLE
Fix: FTL Parallax Background Needlessly Damping

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.cs
@@ -71,6 +71,7 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
     private EntityQuery<MapGridComponent> _gridQuery;
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<TransformComponent> _xformQuery;
+    private readonly Dictionary<EntityUid, float> _ftlDampingBackup = new();
 
     public override void Initialize()
     {
@@ -89,8 +90,8 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
         SubscribeLocalEvent<ShuttleComponent, ComponentStartup>(OnShuttleStartup);
         SubscribeLocalEvent<ShuttleComponent, ComponentShutdown>(OnShuttleShutdown);
         SubscribeLocalEvent<ShuttleComponent, TileFrictionEvent>(OnTileFriction);
-        // SubscribeLocalEvent<ShuttleComponent, FTLStartedEvent>(OnFTLStarted); // Wayfarer: Disable for now
-        // SubscribeLocalEvent<ShuttleComponent, FTLCompletedEvent>(OnFTLCompleted); // Wayfarer: Disable for now
+        SubscribeLocalEvent<ShuttleComponent, FTLStartedEvent>(OnFTLStarted);
+        SubscribeLocalEvent<ShuttleComponent, FTLCompletedEvent>(OnFTLCompleted);
 
         SubscribeLocalEvent<GridInitializeEvent>(OnGridInit);
         NfInitialize(); // Frontier
@@ -182,6 +183,8 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
         if (Comp<MetaDataComponent>(uid).EntityLifeStage >= EntityLifeStage.Terminating)
             return;
 
+        _ftlDampingBackup.Remove(uid);
+
         Disable(uid);
     }
 
@@ -190,16 +193,15 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
         args.Modifier *= ent.Comp.DampingModifier;
     }
 
-    // Wayfarer start: Getting rid of this for now, since we don't have FTL
-    // We can replace this with a simple bool flag if we need it later
-    // private void OnFTLStarted(Entity<ShuttleComponent> ent, ref FTLStartedEvent args)
-    // {
-    //     ent.Comp.DampingModifier = 0f;
-    // }
-    //
-    // private void OnFTLCompleted(Entity<ShuttleComponent> ent, ref FTLCompletedEvent args)
-    // {
-    //     ent.Comp.DampingModifier = ent.Comp.BodyModifier;
-    // }
-    // End Wayfarer
+    private void OnFTLStarted(Entity<ShuttleComponent> ent, ref FTLStartedEvent args)
+    {
+        _ftlDampingBackup[ent.Owner] = ent.Comp.DampingModifier;
+        ent.Comp.DampingModifier = 0f;
+    }
+
+    private void OnFTLCompleted(Entity<ShuttleComponent> ent, ref FTLCompletedEvent args)
+    {
+        if (_ftlDampingBackup.Remove(ent.Owner, out var previousDamping))
+            ent.Comp.DampingModifier = previousDamping;
+    }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR fixes an issue where background stars appeared to slow down over time while a shuttle was in FTL. Re-enabled FTL lifecycle handling in ShuttleSystem.cs. I have no idea why this was commented out. I see no reason for it.

## Why / Balance
Damping suppression during FTL had been disabled (Why? No f**king clue), which caused friction-driven slowdown in hyperspace and made the starfield feel like it was losing speed over time.

## Media
[Screencast_20260529_204106.webm](https://github.com/user-attachments/assets/316026d6-4f66-4d42-a8ab-39c54cd0141f)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [ ] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- fix: Fixed FTL Background Speed Decay
