### PR TITLE
Kills the Pirate sound on Outlaws

### DIFF
--- a/Resources/Prototypes/_NF/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_NF/GameRules/roundstart.yml
@@ -117,7 +117,7 @@
       mindRoles:
       - MindRoleNFPirateCaptain
       briefing: &pirateBriefing
-        sound: "/Audio/_NF/Misc/pirate_greeting.ogg"
+    #    sound: "/Audio/_NF/Misc/pirate_greeting.ogg" # Wayfarer - Commented out for obvious reasons.
     # Pirate First Mate role
 #    - prefRoles: [ NFPirateFirstMate ]
 #      max: 999
@@ -199,7 +199,7 @@
     minimumTimeUntilFirstEvent: 1800 # 30 minutes
     minMaxEventTiming:
       min: 7200 # Wayfarer: 14400<7200 | 2 hours between events
-      max: 14400 # Wayfarer: 21600<14400 | 4 hours between events 
+      max: 14400 # Wayfarer: 21600<14400 | 4 hours between events
 
 - type: entityTable
   id: AutoShipsEventsTable


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I did it chat.

## Why / Balance
Does not fit and should have already been removed.
Devs told me to.

## Technical details
YAML one line
*I lied whitespace cleanup killed something as well.*

## How to test
Join as Outlaw

## Media
*Imagine a picture of a pirate hook with a x over it. Then add another x or two on top for good measure.* 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- remove: Removed the loud as heck Yaar! from outlaw briefing.