### PR TITLE
Lag Mitigation Attempt #1

### DIFF
--- a/Content.Server/Procedural/DungeonSystem.cs
+++ b/Content.Server/Procedural/DungeonSystem.cs
@@ -46,7 +46,7 @@ public sealed partial class DungeonSystem : SharedDungeonSystem
     private EntityQuery<MetaDataComponent> _metaQuery;
     private EntityQuery<TransformComponent> _xformQuery;
 
-    private const double DungeonJobTime = 0.005;
+    private const double DungeonJobTime = 0.001; // Wayfarer: 0.005<0.001
 
     public const int CollisionMask = (int) CollisionGroup.Impassable;
     public const int CollisionLayer = (int) CollisionGroup.Impassable;

--- a/Content.Shared/CCVar/CCVars.Physics.cs
+++ b/Content.Shared/CCVar/CCVars.Physics.cs
@@ -11,7 +11,7 @@ public sealed partial class CCVars
         CVarDef.Create("physics.relative_movement", true, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<float> MinFriction =
-        CVarDef.Create("physics.min_friction", 0.0f, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("physics.min_friction", 0.005f, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER); // # Wayfarer: 0.0f<0.005f
 
     public static readonly CVarDef<float> AirFriction =
         CVarDef.Create("physics.air_friction", 0.2f, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Two small changes, originating from:
https://github.com/Monolith-Station/Monolith/pull/2181
https://github.com/Monolith-Station/Monolith/pull/2220

## Technical details

Change 1:
Adds a minimum friction to everything. The idea here is so that any and all objects obey a minimum friction, eventually stopping in space. Less realism? Sure. More performance, in theory.

Change 2:
Splits dungeon generation jobs across more ticks, allowing vgroid/hulk generation to HOPEFULLY be smoother.
The way I understand this, it seems that RT uses this parameter to pause a job if it took over that amount of time and resumes it on the following tick, easing the workload and hopefully making things smoother. Local testing showed some improvement, but there's a chance it could be placebo.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No player-facing changes.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
