### PR TITLE
Removes some Frontier Damage Regen

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -248,8 +248,8 @@
     damage:
       types:
         Heat: -0.07
-        Shock: -0.07 # Frontier
-        Cold: -0.07 # Frontier
+        #Shock: -0.07 # Frontier # Wayfarer: Commented.
+        #Cold: -0.07 # Frontier # Wayfarer: Ditto.
       groups:
         Brute: -0.07
   - type: Fingerprint


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removes cold and shock damage regen.

## Why / Balance
Frontier added this to base species, but here's the thing, many species override this, which causes the unintended consequence of humans, dwarves and a few other species having extra passive regen for damage types the others do not.

This essentially reverts the species with the extra passive regens to base wizden passive regen.

To confirm this, search for <- type: PassiveDamage> on your IDE to check when this is overwriten.

## Technical details
yaml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Removed likely unintended extra damage regen that had been added to only a few species.
