### PR TITLE
Removes command comms and access from senior peacekeepers.

### DIFF
--- a/Resources/Prototypes/_NF/Access/security.yml
+++ b/Resources/Prototypes/_NF/Access/security.yml
@@ -1,7 +1,7 @@
 - type: accessLevel
   id: Sergeant
   name: id-card-access-level-sergeant
-  
+
 - type: accessLevel
   id: Bailiff
   name: id-card-access-level-bailiff
@@ -17,13 +17,13 @@
   - External
   - Security
   - Brig
-  
+
 - type: accessGroup
   id: GeneralNfsdAccess
   tags:
   - Maintenance
   - External
-  - Command
+  # - Command # Removed, command access is for heads of departments. -Wayfarer
   - Brig
   - Security
   - Mercenary

--- a/Resources/Prototypes/_NF/Access/security.yml
+++ b/Resources/Prototypes/_NF/Access/security.yml
@@ -23,7 +23,7 @@
   tags:
   - Maintenance
   - External
-  # - Command # Removed, command access is for heads of departments. -Wayfarer
+  # - Command # Wayfarer: Removed, command access is for heads of departments.
   - Brig
   - Security
   - Mercenary

--- a/Resources/Prototypes/_WF/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_WF/Loadouts/role_loadouts.yml
@@ -363,7 +363,7 @@
   - NfsdFace
   - NfsdGlasses
   - NfsdBelt
-  - NfsdEarsAltBrown
+  - NfsdEarsBrown # Wayfarer: Removed command comm key from senior peacekeepers
   - NfsdBoxSurvival
   - SeniorPeacekeeperPDA
   - WFWallet


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed senior peacekeeper command key and command access. 

## Why / Balance
Too many command accesses with special CGP carveouts.

## Technical details
Removal of command access from senior peacekeeper ID, remove alternateear from senior peacekeeper loadout. 

## How to test
Load senior peacekeeper. Attempt to access command door, attempt to talk on command channels.

## Media
None

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- remove: Removed senior peacekeeper command access and command comm key.



