### PR TITLE
Revert Vox Age changes, Aurelian small PR #1

### DIFF
--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -14,11 +14,6 @@
   sexes:
   - Unsexed
 
-  minAge: 18    # 500 years is the basis of when vox began to undo their genetic modifications.
-  maxAge: 500   # Because vox are based on their mind and not body, this is a fairly new concept.
-  youngAge: 200
-  oldAge: 350
-
 - type: speciesBaseSprites
   id: MobVoxSprites
   sprites:

--- a/Resources/Prototypes/_WF/Species/aurelianvox.yml
+++ b/Resources/Prototypes/_WF/Species/aurelianvox.yml
@@ -16,11 +16,6 @@
   kind:
   - VoxLike
 
-  minAge: 200
-  maxAge: 500000
-  youngAge: 2000
-  oldAge: 330000
-
   minHeight: 0.9
   defaultHeight: 1.2
   maxHeight: 1.3


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gives the species default age ranges.

## Why / Balance
Your body age should be used not your stack/node/whatever age.

## Technical details
yaml

## How to test
Char creation

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Changed char creation age to default for both Vox.