### PR TITLE
Fixes Capital Thruster Speed

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Structures/Shuttles/capital_thrusters.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Shuttles/capital_thrusters.yml
@@ -36,8 +36,8 @@
   - type: ApcPowerReceiver
     powerLoad: 10000
   - type: Thruster
+    thrust: 660 # Wayfarer: 800<660
     baseThrust: 660 # Wayfarer: 800<660
-    thrust: 660 # Wayfarer: 800<780
     thrustPerPartLevel: [858, 1122, 1386, 1650] # Wayfarer
     burnShape: ["-0.3,0.5","0.2,1.6","0.8,1.6","1.3,0.5"]
     damage:

--- a/Resources/Prototypes/_Mono/Entities/Structures/Shuttles/capital_thrusters.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Shuttles/capital_thrusters.yml
@@ -36,9 +36,9 @@
   - type: ApcPowerReceiver
     powerLoad: 10000
   - type: Thruster
-    thrust: 500 # Wayfarer: 800<500
-    baseThrust: 500 # Wayfarer: 800<500
-    thrustPerPartLevel: [530, 670, 810, 950] # Wayfarer
+    baseThrust: 660 # Wayfarer: 800<660
+    thrust: 660 # Wayfarer: 800<780
+    thrustPerPartLevel: [858, 1122, 1386, 1650] # Wayfarer
     burnShape: ["-0.3,0.5","0.2,1.6","0.8,1.6","1.3,0.5"]
     damage:
       types:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Puts the capital thruster top speed in line with the other thrusters. I got the math wrong the first time.

## Why / Balance
Fix good.

## Technical details
So, there's not a fixed number that truly determines top thruster speed. This number is determined by the percentage of your thruster's upgrades with their parts over the original thrust, in thrustPerPartLevel, which uses the following array:
[ v, x, y, z]
To be in line with the max top speed curve of regular thrusters, V has to be 30% faster than the initial value (basethrust), X has to be 70% faster, Y has to be 110% faster, and Z has to be 150% faster.

Why was it coded this way? Good question.

## How to test
Put the large thrusters on any ship and test them. They have the correct standard speed curve now.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed erroneous capital thruster top speed. Now these have the same top speed curve as normal thrusters, but higher thrust!
