### PR TITLE
Prevents all Entities With AtmosPipeLayersComponent From Being Rotated With the FixRotations command.

### DIFF
--- a/Content.Server/Construction/Commands/FixRotationsCommand.cs
+++ b/Content.Server/Construction/Commands/FixRotationsCommand.cs
@@ -1,10 +1,9 @@
 using Content.Server.Administration;
-using Content.Server.Atmos.Piping.Components;
 using Content.Server.Power.Components;
 using Content.Shared.Administration;
+using Content.Shared.Atmos.Components; // Wayfarer
 using Content.Shared.Construction;
 using Content.Shared.Tag;
-using Content.Shared.Wall;
 using Robust.Shared.Console;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
@@ -80,8 +79,8 @@ public sealed class FixRotationsCommand : IConsoleCommand
                 continue;
             }
             // Wayfarer Start
-            //Atmos devices. We shouldn't rotate these.
-            if (_entManager.HasComponent<AtmosDeviceComponent>(child))
+            //Pipe devices. We shouldn't rotate these.
+            if (_entManager.HasComponent<AtmosPipeLayersComponent>(child))
             {
                 continue;
             }

--- a/Content.Server/Construction/Commands/FixRotationsCommand.cs
+++ b/Content.Server/Construction/Commands/FixRotationsCommand.cs
@@ -1,8 +1,10 @@
 using Content.Server.Administration;
+using Content.Server.Atmos.Piping.Components;
 using Content.Server.Power.Components;
 using Content.Shared.Administration;
 using Content.Shared.Construction;
 using Content.Shared.Tag;
+using Content.Shared.Wall;
 using Robust.Shared.Console;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
@@ -77,6 +79,13 @@ public sealed class FixRotationsCommand : IConsoleCommand
             {
                 continue;
             }
+            // Wayfarer Start
+            //Atmos devices. We shouldn't rotate these.
+            if (_entManager.HasComponent<AtmosDeviceComponent>(child))
+            {
+                continue;
+            }
+            // Wayfarer End
 
             var valid = false;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Does as the title says.

## Why / Balance
Tags are annoying and this forces all atmos devices that deal with pipes and pressure to comply. These probably should not be getting rotated anyways...
Regardless, this fixes an issue with fixrotations rotating vox scrubbers and vents, alongside possibly any other things.

## Technical details
<!-- Summary of code changes for easier review. -->
Simple check continue if the component is detected.

## How to test
Aghost, Mapping 1000, load any grid, map some vox atmos scrubbers in different directions, run the fixrotations command, see they don't rotate anymore.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No player-facing changes. Mapper stuff only.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
