### PR TITLE
Removes Holdover Syndicate Access From 3 Machines

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -493,6 +493,7 @@
   - type: VendingMachineRestock
     canRestock:
     - ChemVendInventory
+    - ChemVendInventorySyndicate # Wayfarer
   - type: Sprite
     layers:
     - state: base

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -322,8 +322,8 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["SyndicateAgent"]]
+  #- type: AccessReader # Wayfarer:
+  #  access: [["SyndicateAgent"]]
   - type: GuideHelp
     guides:
     - Bartender
@@ -2004,8 +2004,8 @@
     radius: 1.5
     energy: 3.0
     color: "#d82929"
-  - type: AccessReader
-    access: [["NuclearOperative"], ["SyndicateAgent"]]
+  #- type: AccessReader # Wayfarer
+  #  access: [["NuclearOperative"], ["SyndicateAgent"]]
 
 - type: entity
   parent: VendingMachine
@@ -2259,8 +2259,8 @@
     normalState: normal
     denyState: deny
     ejectDelay: 2
-  - type: AccessReader
-    access: [["SyndicateAgent"]]
+  #- type: AccessReader # Wayfarer
+  #  access: [["SyndicateAgent"]]
 
 # wallmount
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removes syndicate access requirement from the syndie juice, the bruise-o-mat and the Syndie Drobe.
Also allows the syndie juice to be restocked by chemvend restocks. (It's frankly just a really rare chemvend)

## Why / Balance
Some of these spawn in expeds/vroids and they're unusable. This changes that.

## Technical details
yml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: A few vroid/exped vending machines now have general access.
