### PR TITLE
Restore PM whitelist

### DIFF
--- a/Resources/Prototypes/_NF/Roles/Jobs/Engineering/plant_manager.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Engineering/plant_manager.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 72000 # Frontier - 20 hrs (the real condition here is the whitelist)
-  whitelisted: false # Wayfarer: true<false
+  whitelisted: true # Wayfarer: false<true # WHITELIST REQUIREMENTS: BUILD A FUNCTIONAL TESLA, TEG OR NUCLEAR REACTOR
   startingGear: PlantManagerGear
   alwaysUseSpawner: true
   icon: "JobIconPlantManager"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Restores whitelist requirement to Plant Manager
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Command staff should be whitelisted.
They are the only role outside of ERT with access to unrestricted RCDs