### PR TITLE
Ports: Fix Infoshades inventory footprint (Frontier #4449)

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Clothing/Eyes/glasses_punks.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Eyes/glasses_punks.yml
@@ -40,15 +40,14 @@
 # HUDs
 - type: entity
   id: ClothingEyesPunkInfoShades
-  parent: [ ClothingEyesHudMedical, RecyclableItemClothDevice ]
+  parent: [ ClothingEyesBase, RecyclableItemClothDevice ]
   name: punk infoshades
   description: How can you see anything in this with all the lights?
   components:
   - type: VisionCorrection
   - type: Item
     shape:
-    - 0,0,1,0
-    storedOffset: -20,-20
+    - 0,0,0,1
   - type: Sprite
     sprite: _NF/Clothing/Eyes/Glasses/punk_glasses.rsi
     layers:

--- a/Resources/Prototypes/_NF/Entities/Clothing/Eyes/glasses_punks.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Eyes/glasses_punks.yml
@@ -40,7 +40,7 @@
 # HUDs
 - type: entity
   id: ClothingEyesPunkInfoShades
-  parent: [ ClothingEyesBase, RecyclableItemClothDevice ] # Wayfarer: ClothingEyesBase<ClothingEyesHudMedical
+  parent: [ ClothingEyesHudMedical, RecyclableItemClothDevice ] # Wayfarer: ClothingEyesBase<ClothingEyesHudMedical
   name: punk infoshades
   description: How can you see anything in this with all the lights?
   components:

--- a/Resources/Prototypes/_NF/Entities/Clothing/Eyes/glasses_punks.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Eyes/glasses_punks.yml
@@ -40,7 +40,7 @@
 # HUDs
 - type: entity
   id: ClothingEyesPunkInfoShades
-  parent: [ ClothingEyesBase, RecyclableItemClothDevice ]
+  parent: [ ClothingEyesBase, RecyclableItemClothDevice ] # Wayfarer: ClothingEyesBase<ClothingEyesHudMedical
   name: punk infoshades
   description: How can you see anything in this with all the lights?
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Ports https://github.com/new-frontiers-14/frontier-station-14/pull/4449
But kept the icon, parent, documenting it.

## Why / Balance
When removed, these squiggle all over the inventory. This fixes that.

## How to test
Get infoshades, put them in your inventory, see they do not offset anymore.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="263" height="131" alt="image" src="https://github.com/user-attachments/assets/c1e0e8f7-71fc-4a23-882e-daf7c5b4e810" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed infoshades' inventory footprint.
