### PR TITLE
Rebalances Xenoarch Artifact Explosion Weightage

### DIFF
--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -34,7 +34,7 @@
     - id: XenoArtifactColdWave
       weight: 10.0
     - id: XenoArtifactHeatWave
-      weight: 4.0
+      weight: 5.0 # Frontier: 4.0<5.0
     - id: XenoArtifactFoamMild
       weight: 8.0
     - id: XenoArtifactRandomInstrumentSpawn
@@ -78,7 +78,7 @@
     - id: XenoArtifactAnomalySpawn
       weight: 4.0 # Frontier: 10.0<4.0
     - id: XenoArtifactIgnite
-      weight: 2.0
+      weight: 3.0 # Frontier: 2.0<3.0
     - id: XenoArtifactTeleport
       weight: 2.0
     - id: XenoArtifactEmp
@@ -112,9 +112,9 @@
     - id: XenoArtifactExplosionScary
       weight: 0.5 # Wayfarer: 1<0.5
     - id: XenoArtifactBoom
-      weight: 3.5 # Wayfarer: 5.0<3.5
+      weight: 0.5 # Wayfarer: 5.0<0.5
     - id: XenoArtifactEffectCreationGasPlasma
-      weight: 2.0
+      weight: 3.0 # Frontier: 2.0<3.0
     - id: XenoArtifactEffectCreationGasTritium
       weight: 2.0
     - id: XenoArtifactEffectCreationGasAmmonia

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -34,7 +34,7 @@
     - id: XenoArtifactColdWave
       weight: 10.0
     - id: XenoArtifactHeatWave
-      weight: 5.0 # Frontier: 4.0<5.0
+      weight: 5.0 # Wayfarer: 4.0<5.0
     - id: XenoArtifactFoamMild
       weight: 8.0
     - id: XenoArtifactRandomInstrumentSpawn
@@ -78,7 +78,7 @@
     - id: XenoArtifactAnomalySpawn
       weight: 4.0 # Frontier: 10.0<4.0
     - id: XenoArtifactIgnite
-      weight: 3.0 # Frontier: 2.0<3.0
+      weight: 3.0 # Wayfarer: 2.0<3.0
     - id: XenoArtifactTeleport
       weight: 2.0
     - id: XenoArtifactEmp
@@ -114,7 +114,7 @@
     - id: XenoArtifactBoom
       weight: 0.5 # Wayfarer: 5.0<0.5
     - id: XenoArtifactEffectCreationGasPlasma
-      weight: 3.0 # Frontier: 2.0<3.0
+      weight: 3.0 # Wayfarer: 2.0<3.0
     - id: XenoArtifactEffectCreationGasTritium
       weight: 2.0
     - id: XenoArtifactEffectCreationGasAmmonia


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Currently, a xenoarch artifact has an approximate 1.25% chance to generate a large explosion node that causes instant death for anyone in a 5 tile radius when triggered, in addition to destroying the artifact and the analyzer pad. Considering that most xenoarch effects require close-up interaction to trigger and how finicky it is to trigger the effects, most scientists are inclined to stay within the danger zone repeating the effect triggers in hopes of getting it to stick. Whilst this could be argued as giving medical more things to do, having the analyzer pad destroyed early-on before you are able to research the technology to build more analyzer pads means you are completely dead in the water and you will have wasted your time, money, and effort attempting to perform science.

To put it simply, proccing the explosion is simply unfun and does not contribute to making the round more exciting in any way whatsoever. Anecdotally speaking, a casual science run will encounter two explosions during the average play session, and it can occur early enough to completely lock you out of doing science altogether.

To that end, this PR reduces the weightage of the large explosion effect and redistributes the lost weightage to other effects (Plasma generation, heatwave, and ignition. Makes things more exciting without being a guaranteed deadly explosion.) to bring its proc chance down to approximately 0.2%.

**Changelog**
:cl: Toriate
- tweak: Proc chance of large explosion effect on xenoarch artifacts has been reduced. Plasma generation, heatwave, and ignition effect chances increased to compensate.
