### PR TITLE
Deathrattle Medical Implant Repeat System and Toggle

### DIFF
--- a/Content.Server/Trigger/Systems/RattleOnTriggerSystem.cs
+++ b/Content.Server/Trigger/Systems/RattleOnTriggerSystem.cs
@@ -9,6 +9,11 @@ using Robust.Server.GameObjects; // Frontier
 using Content.Server.Station.Systems; // Frontier
 using Content.Shared.Humanoid; // Frontier
 
+using System.Threading; // Wayfarer
+using Content.Shared.Mobs; // wayfarer
+using Content.Shared.Radio; // Wayfarer
+using Timer = Robust.Shared.Timing.Timer; // Wayfarer
+
 namespace Content.Server.Trigger.Systems;
 
 public sealed class RattleOnTriggerSystem : EntitySystem
@@ -18,6 +23,8 @@ public sealed class RattleOnTriggerSystem : EntitySystem
     [Dependency] private readonly NavMapSystem _navMap = default!;
     [Dependency] private readonly TransformSystem _transform = default!; // Frontier
     [Dependency] private readonly StationSystem _station = default!; // Frontier
+
+    private readonly Dictionary<EntityUid, CancellationTokenSource> _stillDeadTimers = new(); // Wayfarer
 
     public override void Initialize()
     {
@@ -70,5 +77,66 @@ public sealed class RattleOnTriggerSystem : EntitySystem
 
         // Sends a message to the radio channel specified by the implant
         _radio.SendRadioMessage(ent.Owner, message, _prototypeManager.Index(ent.Comp.RadioChannel), ent.Owner);
+
+        if (mobstate.CurrentState == MobState.Dead) // Wayfarer: Start the "still dead" timer if the user is, well, still dead.
+            StartStillDeadTimer(target.Value, ent.Comp.RadioChannel, ent.Comp.RattleRefireDelay);
     }
+
+    // Wayfarer Start
+private void StartStillDeadTimer(EntityUid entity, ProtoId<RadioChannelPrototype> channel, TimeSpan delay)
+    {
+        if (_stillDeadTimers.TryGetValue(entity, out var existingCts))
+            existingCts.Cancel();
+
+        var cts = new CancellationTokenSource();
+        _stillDeadTimers[entity] = cts;
+
+        // Repeating timer callback, gee golly I hope this doesn't come back said the timer
+        void TimerCallback()
+        {
+            if (cts.Token.IsCancellationRequested)
+                return;
+
+            if (!EntityManager.EntityExists(entity) ||
+                !TryComp<MobStateComponent>(entity, out var mobState) ||
+                mobState.CurrentState != MobState.Dead)
+            {
+                _stillDeadTimers.Remove(entity);
+                return;
+            }
+
+            // Build and send the "still dead" message, kinda like coyote's.
+            var mapPos = _transform.GetMapCoordinates(entity);
+            var posText = $"({(int)mapPos.X}, {(int)mapPos.Y})";
+
+            var station = _station.GetOwningStation(entity);
+            var stationText = station is null ? "" : $"{Name(station.Value)} ";
+
+            var speciesText = "";
+            if (TryComp<HumanoidAppearanceComponent>(entity, out var species))
+                speciesText = $" ({species.Species})";
+
+            var message = Loc.GetString("rattle-on-trigger-dead-message-still",
+                ("user", entity),
+                ("specie", speciesText),
+                ("grid", stationText!),
+                ("position", posText));
+
+            _radio.SendRadioMessage(entity, message, _prototypeManager.Index(channel), entity);
+
+            // Schedule the next reminder
+            Timer.Spawn(delay, TimerCallback, cts.Token);
+        }
+
+        Timer.Spawn(delay, TimerCallback, cts.Token);
+    }
+
+    public override void Shutdown() // Keeps it from causing an error just in case an entity is deleted with an active timer and rattle.
+    {
+        base.Shutdown();
+        foreach (var cts in _stillDeadTimers.Values)
+            cts.Cancel();
+        _stillDeadTimers.Clear();
+    }
+    // Wayfarer End
 }

--- a/Content.Server/Trigger/Systems/RattleOnTriggerSystem.cs
+++ b/Content.Server/Trigger/Systems/RattleOnTriggerSystem.cs
@@ -83,7 +83,7 @@ public sealed class RattleOnTriggerSystem : EntitySystem
     }
 
     // Wayfarer Start
-private void StartStillDeadTimer(EntityUid entity, ProtoId<RadioChannelPrototype> channel, TimeSpan delay)
+    private void StartStillDeadTimer(EntityUid entity, ProtoId<RadioChannelPrototype> channel, TimeSpan delay)
     {
         if (_stillDeadTimers.TryGetValue(entity, out var existingCts))
             existingCts.Cancel();

--- a/Content.Shared/Implants/SharedSubdermalImplantSystem.Relays.cs
+++ b/Content.Shared/Implants/SharedSubdermalImplantSystem.Relays.cs
@@ -2,6 +2,7 @@ using Content.Shared.Implants.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Mobs;
+using Content.Shared.Verbs; // Wayfarer
 
 namespace Content.Shared.Implants;
 
@@ -12,6 +13,7 @@ public abstract partial class SharedSubdermalImplantSystem
         SubscribeLocalEvent<ImplantedComponent, MobStateChangedEvent>(RelayToImplantEvent);
         SubscribeLocalEvent<ImplantedComponent, AfterInteractUsingEvent>(RelayToImplantEvent);
         SubscribeLocalEvent<ImplantedComponent, SuicideEvent>(RelayToImplantEvent);
+        SubscribeLocalEvent<ImplantedComponent, GetVerbsEvent<Verb>>(RelayToImplantEvent); // Wayfarer
     }
 
     /// <summary>

--- a/Content.Shared/Trigger/Components/Effects/RattleOnTriggerComponent.cs
+++ b/Content.Shared/Trigger/Components/Effects/RattleOnTriggerComponent.cs
@@ -32,6 +32,7 @@ public sealed partial class RattleOnTriggerComponent : BaseXOnTriggerComponent
     /// <summary>
     /// The delay before the deathrattle implant sends the message again
     /// </summary>
+    [ViewVariables]
     [DataField]
     public TimeSpan RattleRefireDelay = TimeSpan.FromMinutes(20);
     // Wayfarer End

--- a/Content.Shared/Trigger/Components/Effects/RattleOnTriggerComponent.cs
+++ b/Content.Shared/Trigger/Components/Effects/RattleOnTriggerComponent.cs
@@ -27,4 +27,12 @@ public sealed partial class RattleOnTriggerComponent : BaseXOnTriggerComponent
         {MobState.Critical, "rattle-on-trigger-critical-message"},
         {MobState.Dead, "rattle-on-trigger-dead-message"}
     };
+
+    // Wayfarer Start
+    /// <summary>
+    /// The delay before the deathrattle implant sends the message again
+    /// </summary>
+    [DataField]
+    public TimeSpan RattleRefireDelay = TimeSpan.FromMinutes(20);
+    // Wayfarer End
 }

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnMobstateChangeComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnMobstateChangeComponent.cs
@@ -30,6 +30,15 @@ public sealed partial class TriggerOnMobstateChangeComponent : BaseTriggerOnXCom
     [DataField, AutoNetworkedField]
     public bool PreventVore = false;
 
+    // Wayfarer Start
+    /// <summary>
+    /// If false, this component will not trigger / is not allowed to work.
+    /// </summary>
+    [ViewVariables]
+    [DataField]
+    public bool Enabled = true;
+    // Wayfarer End
+
     /// <summary>
     /// If false, the trigger user will be the entity that caused the mobstate to change.
     /// If true, the trigger user will the entity that changed its mob state.

--- a/Content.Shared/Trigger/Systems/TriggerOnMobstateChangeSystem.cs
+++ b/Content.Shared/Trigger/Systems/TriggerOnMobstateChangeSystem.cs
@@ -5,6 +5,8 @@ using Content.Shared.Mobs;
 using Content.Shared.Popups;
 using Content.Shared.Trigger.Components.Triggers;
 
+using Content.Shared.Verbs; // Wayfarer
+
 namespace Content.Shared.Trigger.Systems;
 
 public sealed partial class TriggerOnMobstateChangeSystem : EntitySystem
@@ -21,6 +23,7 @@ public sealed partial class TriggerOnMobstateChangeSystem : EntitySystem
 
         SubscribeLocalEvent<TriggerOnMobstateChangeComponent, ImplantRelayEvent<MobStateChangedEvent>>(OnMobStateRelay);
         SubscribeLocalEvent<TriggerOnMobstateChangeComponent, ImplantRelayEvent<SuicideEvent>>(OnSuicideRelay);
+        SubscribeLocalEvent<TriggerOnMobstateChangeComponent, ImplantRelayEvent<GetVerbsEvent<Verb>>>(OnVerbRelay); // Wayfarer
     }
 
     private void OnMobStateChanged(EntityUid uid, TriggerOnMobstateChangeComponent component, MobStateChangedEvent args)
@@ -38,6 +41,9 @@ public sealed partial class TriggerOnMobstateChangeSystem : EntitySystem
 
         if (component.PreventVore && HasComp<VoredComponent>(args.ImplantedEntity))
             return;
+
+        if (!component.Enabled)
+            return; // Wayfarer
 
         _trigger.Trigger(uid, component.TargetMobstateEntity ? args.ImplantedEntity : args.Event.Origin, component.KeyOut);
     }

--- a/Content.Shared/_WF/Trigger/Systems/TriggerOnMobstateChangeSystem.cs
+++ b/Content.Shared/_WF/Trigger/Systems/TriggerOnMobstateChangeSystem.cs
@@ -1,0 +1,51 @@
+using Content.Shared.FloofStation;
+using Content.Shared.Implants;
+using Content.Shared.Interaction.Events;
+using Content.Shared.Mobs;
+using Content.Shared.Popups;
+using Content.Shared.Trigger.Components.Triggers;
+
+using Content.Shared.Verbs; // Wayfarer
+
+
+namespace Content.Shared.Trigger.Systems;
+
+public sealed partial class TriggerOnMobstateChangeSystem : EntitySystem
+{
+    private void OnVerbRelay(EntityUid uid,
+        TriggerOnMobstateChangeComponent component,
+        ImplantRelayEvent<GetVerbsEvent<Verb>> args)
+    {
+        OnGetVerbs(uid, component, args.Event);
+    }
+
+    private void OnGetVerbs(EntityUid uid,
+        TriggerOnMobstateChangeComponent component,
+        GetVerbsEvent<Verb> args)
+    {
+        if (args.User != args.Target)
+            return; // Self only, but usable in crit
+
+        // I can't for the life of me stop this from displaying the popup twice. Is what it is.
+        var verb = new Verb()
+        {
+            Text = Loc.GetString(
+                "trigger-on-mobstate-verb-text",
+                ("implant", Name(uid)),
+                ("state", component.Enabled ? "ON" : "OFF")),
+            Act = () =>
+            {
+                component.Enabled = !component.Enabled;
+                _popup.PopupEntity(
+                    Loc.GetString(
+                        "trigger-on-mobstate-verb-popup",
+                        ("state", component.Enabled ? "ENABLED" : "DISABLED")),
+                    args.User,
+                    args.User);
+            },
+            Disabled = false,
+            Message = Loc.GetString("trigger-on-mobstate-verb-description"),
+        };
+        args.Verbs.Add(verb);
+    }
+}

--- a/Resources/Locale/en-US/_CS/radio_static.ftl
+++ b/Resources/Locale/en-US/_CS/radio_static.ftl
@@ -15,6 +15,3 @@ verb-categories-radiovolume = Radio Volume
 radio-volume-verb = VOL: {$volume}
 radio-volume-verb-popup = Radio Volume: {$volume}
 
-trigger-on-mobstate-verb-text = MedImplant: {$state}
-trigger-on-mobstate-verb-popup = Your MedAlert Beacon is set to: {$state}
-

--- a/Resources/Locale/en-US/_WF/triggers/on-mobstate-verb.ftl
+++ b/Resources/Locale/en-US/_WF/triggers/on-mobstate-verb.ftl
@@ -1,0 +1,3 @@
+trigger-on-mobstate-verb-text = {$implant} ({$state})
+trigger-on-mobstate-verb-popup = Your MedAlert Beacon is set to: {$state}
+trigger-on-mobstate-verb-description = Toggle whether or not this thing tells everyone you are dead both inside and outside.

--- a/Resources/Locale/en-US/_WF/triggers/rattle-on-trigger.ftl
+++ b/Resources/Locale/en-US/_WF/triggers/rattle-on-trigger.ftl
@@ -1,0 +1,1 @@
+rattle-on-trigger-dead-message-still = {$user}{$specie} is STILL dead at {$grid}{$position}!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Implements a repeating alert function for people that died, inspired on coyote's implementation of this system.

By request, also adds a toggle for the rattle, from https://github.com/ARF-SS13/coyote-frontier/pull/299 but changed a little.

## Why / Balance
If someone dies and there's no medical to see their death, it is incredibly likely that their death will go unnoticed.
This changes that, by adding a repeat alert, in similar fashion to coyote but with an entirely different implementation (our trigger system is much more up to date and needed a different approach)

## Technical details
Pain and suffering. Cancellation Tokens are weird, this is my first time ever touching them. Why is this not simpler, I wonder.

## How to test
Spawn yourself with an implant, aghost, shoot your character until they're dead. Observe that after 20 minutes (configurable) the message is pushed again.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="472" height="851" alt="image" src="https://github.com/user-attachments/assets/6e7ea456-c749-43a2-8701-a66ca31f8c7e" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Medical implants should now repeat the deaths of players that have been dead for 20 minutes.
