### PR TITLE
Fixes Ovinia Emote Punctuation

### DIFF
--- a/Resources/Prototypes/_DEN/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/_DEN/Voice/speech_emotes.yml
@@ -17,7 +17,7 @@
   blacklist:
     components:
     - BorgChassis
-  chatMessages: [ moos ]
+  chatMessages: [ moos. ] # Wayfarer: added punctuation.
   chatTriggers:
     - moos
     - moo
@@ -33,7 +33,7 @@
   blacklist:
     components:
     - BorgChassis
-  chatMessages: [ baas ]
+  chatMessages: [ baas. ] # Wayfarer: added punctuation.
   chatTriggers:
     - baas
     - baa


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title

## Why / Balance
The emotes were missing punctuation.

## Technical details
Adds a two whole dots.

## How to test
As an ovinia, baa and moo.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed missing punctuation in ovinia emotes.
