### PR TITLE
Add IPC EMP shock system to handle electrocution effects

### DIFF
--- a/Content.Server/_EinsteinEngines/Silicon/EmpShock/SiliconEmpShockSystem.cs
+++ b/Content.Server/_EinsteinEngines/Silicon/EmpShock/SiliconEmpShockSystem.cs
@@ -1,0 +1,32 @@
+// Wayfarer: IPC EMP shock system
+using Content.Server.Electrocution;
+using Content.Server.Emp;
+using Content.Shared._EinsteinEngines.Silicon.Components;
+
+namespace Content.Server._EinsteinEngines.Silicon.EmpShock;
+
+/// <summary>
+/// Wayfarer: This system handles IPCs getting shocked when struck by an EMP,
+/// similar to how humans get shocked when touching an electrified door.
+/// </summary>
+public sealed class SiliconEmpShockSystem : EntitySystem
+{
+    [Dependency] private readonly ElectrocutionSystem _electrocution = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SiliconComponent, EmpPulseEvent>(OnEmpPulse);
+    }
+
+    private void OnEmpPulse(EntityUid uid, SiliconComponent component, ref EmpPulseEvent args)
+    {
+        // Wayfarer: Apply a short shock effect when the IPC is hit by EMP
+        // Similar to touching an electrified door
+        // Damage: 5 shock damage (relatively minor)
+        // Duration: 3 seconds of stun/jitter
+        _electrocution.TryDoElectrocution(uid, null, 5, TimeSpan.FromSeconds(3), true);
+    }
+}
+// End Wayfarer


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I've added a new system that makes IPCs get a short shocked effect when struck by an EMP, similar to how humans get shocked when touching an electrified door. This PR was requested by Feathernights.

5 shock damage (which becomes ~12.5 damage due to IPCs' 2.5x shock damage multiplier)
3 seconds of stunning & jittering effect

## Why / Balance
Balances IPC a little bit

## Technical details
The system listens for EmpPulseEvent on any entity with a SiliconComponent (which includes all IPCs). 

## Media
[Screencast_20260608_134451.webm](https://github.com/user-attachments/assets/8219ade6-c238-4f87-afdd-2720d736cc2d)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: IPC get shocked upon being EMP'd and take shock damage
