### PR TITLE
Makes the artifact analyzer drop its board on destruction

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/artifact_analyzer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/artifact_analyzer.yml
@@ -79,6 +79,27 @@
         enum.PowerDeviceVisualLayers.Powered:
           True: { visible: true }
           False: { visible: false }
+  # Start Wayfarer: Allow artifact analyzer to drop its machine board on destruction.
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 600
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: MetalBreak
+          - !type:DoActsBehavior
+            acts: ["Destruction"]
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              ArtifactAnalyzerMachineCircuitboard:
+                min: 1
+                max: 1
+              SheetSteel1:
+                min: 2
+                max: 4
+  # End Wayfarer: Allow artifact analyzer to drop its machine board on destruction.
 
 - type: entity
   id: MachineArtifactCrusher

--- a/Resources/Prototypes/Entities/Structures/Machines/artifact_analyzer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/artifact_analyzer.yml
@@ -79,7 +79,7 @@
         enum.PowerDeviceVisualLayers.Powered:
           True: { visible: true }
           False: { visible: false }
-  # Start Wayfarer: Allow artifact analyzer to drop its machine board on destruction.
+  # Wayfarer: Allow artifact analyzer to drop its machine board on destruction.
   - type: Destructible
     thresholds:
       - trigger:
@@ -99,7 +99,7 @@
               SheetSteel1:
                 min: 2
                 max: 4
-  # End Wayfarer: Allow artifact analyzer to drop its machine board on destruction.
+  # End Wayfarer
 
 - type: entity
   id: MachineArtifactCrusher


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR was made as an alternative to #1123. By making the artifact analyzer board drop upon its destruction, it alleviates the issue of early explosive artifacts ruining a new scientists' run. It should be noted that explosions will have a tendency of launching the board off into the distance, which may be troublesome in some cases.

Additionally, the way this is implemented adds an effective healthbar to the artifact analyzer, which would make it take damage from many of the other artifact effects and necessitate welder repairs.

## How to test
<img width="469" height="469" alt="Content Client_U5C4tRnMUR" src="https://github.com/user-attachments/assets/7e1fbe7f-bb45-4a5d-9cd8-e5a29977a4e5" />
<img width="511" height="437" alt="Content Client_Cl9kt3ROIV" src="https://github.com/user-attachments/assets/e1864c6c-84a9-41fd-9bb0-dce1cf166354" />
<img width="1387" height="508" alt="Content Client_naFnBFUPDI" src="https://github.com/user-attachments/assets/fd830bf7-f093-4de6-9372-3ee36033cc2c" />


**Changelog**
:cl: Toriate
- tweak: Artifact analyzers now drop their machine board upon destruction.
