### PR TITLE
small ship tweak

### DIFF
--- a/Resources/Maps/_WF/Shuttles/Expedition/behir.yml
+++ b/Resources/Maps/_WF/Shuttles/Expedition/behir.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 267.3.0
   forkId: ""
   forkVersion: ""
-  time: 06/04/2026 23:41:24
-  entityCount: 1045
+  time: 06/09/2026 09:22:34
+  entityCount: 1046
 maps: []
 grids:
 - 1
@@ -5765,34 +5765,34 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        941:
-        - - Pressed
-          - Off
-        939:
+        942:
         - - Pressed
           - Off
         940:
         - - Pressed
           - Off
-        906:
+        941:
         - - Pressed
           - Off
         907:
         - - Pressed
           - Off
+        908:
+        - - Pressed
+          - Off
+        906:
+        - - Pressed
+          - Off
         905:
         - - Pressed
           - Off
-        904:
+        939:
         - - Pressed
           - Off
         938:
         - - Pressed
           - Off
-        937:
-        - - Pressed
-          - Off
-        942:
+        943:
         - - Pressed
           - Off
     - type: Fixtures
@@ -5811,34 +5811,34 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        906:
-        - - Pressed
-          - On
-        905:
-        - - Pressed
-          - On
-        938:
-        - - Pressed
-          - On
-        937:
-        - - Pressed
-          - On
-        904:
-        - - Pressed
-          - On
         907:
         - - Pressed
           - On
-        940:
+        906:
         - - Pressed
           - On
         939:
         - - Pressed
           - On
+        938:
+        - - Pressed
+          - On
+        905:
+        - - Pressed
+          - On
+        908:
+        - - Pressed
+          - On
         941:
         - - Pressed
           - On
+        940:
+        - - Pressed
+          - On
         942:
+        - - Pressed
+          - On
+        943:
         - - Pressed
           - On
     - type: Fixtures
@@ -5913,30 +5913,37 @@ entities:
     - type: Transform
       pos: 5.491255,11.482097
       parent: 1
-- proto: NFMagnetBoxConstruction
+- proto: NFHolopadShip
   entities:
   - uid: 749
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 1
+- proto: NFMagnetBoxConstruction
+  entities:
+  - uid: 750
     components:
     - type: Transform
       pos: 10.5,0.5
       parent: 1
 - proto: NFMagnetBoxOre
   entities:
-  - uid: 750
+  - uid: 751
     components:
     - type: Transform
       pos: 9.5,0.5
       parent: 1
 - proto: NFPlushieCmo
   entities:
-  - uid: 751
+  - uid: 752
     components:
     - type: Transform
       pos: 6.1559525,-4.3239994
       parent: 1
 - proto: NitrogenCanister
   entities:
-  - uid: 752
+  - uid: 753
     components:
     - type: Transform
       anchored: True
@@ -5944,21 +5951,21 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Static
-  - uid: 753
+  - uid: 754
     components:
     - type: Transform
       pos: 11.5,-7.5
       parent: 1
 - proto: OreProcessor
   entities:
-  - uid: 754
+  - uid: 755
     components:
     - type: Transform
       pos: 9.5,5.5
       parent: 1
 - proto: OxygenCanister
   entities:
-  - uid: 755
+  - uid: 756
     components:
     - type: Transform
       anchored: True
@@ -5968,7 +5975,7 @@ entities:
       bodyType: Static
 - proto: PanFlag
   entities:
-  - uid: 756
+  - uid: 757
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5978,102 +5985,102 @@ entities:
       fixtures: {}
 - proto: PlasmaWindow
   entities:
-  - uid: 757
+  - uid: 758
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 758
+  - uid: 759
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
-  - uid: 759
+  - uid: 760
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 1
-  - uid: 760
+  - uid: 761
     components:
     - type: Transform
       pos: 8.5,-1.5
       parent: 1
-  - uid: 761
+  - uid: 762
     components:
     - type: Transform
       pos: 9.5,-1.5
       parent: 1
-  - uid: 762
+  - uid: 763
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 763
+  - uid: 764
     components:
     - type: Transform
       pos: 11.5,-4.5
       parent: 1
-  - uid: 764
+  - uid: 765
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 1
-  - uid: 765
+  - uid: 766
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
-  - uid: 766
+  - uid: 767
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 1
-  - uid: 767
+  - uid: 768
     components:
     - type: Transform
       pos: 14.5,-8.5
       parent: 1
-  - uid: 768
+  - uid: 769
     components:
     - type: Transform
       pos: 14.5,-9.5
       parent: 1
-  - uid: 769
+  - uid: 770
     components:
     - type: Transform
       pos: 14.5,-10.5
       parent: 1
 - proto: PlushieCoffeeFox
   entities:
-  - uid: 770
+  - uid: 771
     components:
     - type: Transform
       pos: 6.787348,-4.1004524
       parent: 1
 - proto: PlushieLizard
   entities:
-  - uid: 771
+  - uid: 772
     components:
     - type: Transform
       pos: 8.683798,14.864493
       parent: 1
 - proto: PlushieLizardMirrored
   entities:
-  - uid: 772
+  - uid: 773
     components:
     - type: Transform
       pos: 6.340048,14.562409
       parent: 1
 - proto: PlushieSharkBlue
   entities:
-  - uid: 773
+  - uid: 774
     components:
     - type: Transform
       pos: 6.687603,-4.909214
       parent: 1
 - proto: PolyFlag
   entities:
-  - uid: 774
+  - uid: 775
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6083,16 +6090,16 @@ entities:
       fixtures: {}
 - proto: PortableGeneratorSuperPacmanShuttle
   entities:
-  - uid: 775
+  - uid: 776
     components:
     - type: Transform
       pos: 13.5,-8.5
       parent: 1
     - type: FuelGenerator
-      targetPower: 33000
+      targetPower: 34000
 - proto: PosterBroken
   entities:
-  - uid: 776
+  - uid: 777
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6102,7 +6109,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandBeachStarYamamoto
   entities:
-  - uid: 777
+  - uid: 778
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6112,7 +6119,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandExoChomp
   entities:
-  - uid: 778
+  - uid: 779
     components:
     - type: Transform
       pos: 2.5,8.5
@@ -6121,7 +6128,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandHaveaPuff
   entities:
-  - uid: 779
+  - uid: 780
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6131,7 +6138,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandPunchShit
   entities:
-  - uid: 780
+  - uid: 781
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6141,7 +6148,7 @@ entities:
       fixtures: {}
 - proto: PosterLegit12Gauge
   entities:
-  - uid: 781
+  - uid: 782
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6151,7 +6158,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitCarpMount
   entities:
-  - uid: 782
+  - uid: 783
     components:
     - type: Transform
       pos: 3.5,-5.5
@@ -6160,7 +6167,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitSafetyInternals
   entities:
-  - uid: 783
+  - uid: 784
     components:
     - type: Transform
       pos: 2.5,-1.5
@@ -6169,7 +6176,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitSafetyMothFires
   entities:
-  - uid: 784
+  - uid: 785
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6179,7 +6186,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitSafetyMothHardhat
   entities:
-  - uid: 785
+  - uid: 786
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6189,55 +6196,55 @@ entities:
       fixtures: {}
 - proto: PottedPlant10
   entities:
-  - uid: 786
+  - uid: 787
     components:
     - type: Transform
       pos: 8.5,-5.5
       parent: 1
 - proto: PottedPlant15
   entities:
-  - uid: 787
+  - uid: 788
     components:
     - type: Transform
       pos: 8.5,7.5
       parent: 1
 - proto: PottedPlant3
   entities:
-  - uid: 788
+  - uid: 789
     components:
     - type: Transform
       pos: 6.444746,13.494832
       parent: 1
 - proto: Poweredlight
   entities:
-  - uid: 789
+  - uid: 790
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 790
-    components:
-    - type: Transform
-      pos: 11.5,5.5
-      parent: 1
   - uid: 791
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-2.5
+      pos: 11.5,5.5
       parent: 1
   - uid: 792
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 11.5,-2.5
+      pos: 3.5,-2.5
       parent: 1
   - uid: 793
     components:
     - type: Transform
-      pos: 8.5,10.5
+      rot: 3.141592653589793 rad
+      pos: 11.5,-2.5
       parent: 1
   - uid: 794
+    components:
+    - type: Transform
+      pos: 8.5,10.5
+      parent: 1
+  - uid: 795
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6245,19 +6252,19 @@ entities:
       parent: 1
 - proto: PoweredlightBlue
   entities:
-  - uid: 795
+  - uid: 796
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-5.5
       parent: 1
-  - uid: 796
+  - uid: 797
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-5.5
       parent: 1
-  - uid: 797
+  - uid: 798
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6265,35 +6272,35 @@ entities:
       parent: 1
 - proto: PoweredlightExterior
   entities:
-  - uid: 798
+  - uid: 799
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,16.5
       parent: 1
-  - uid: 799
+  - uid: 800
     components:
     - type: Transform
       pos: 3.5,-12.5
       parent: 1
-  - uid: 800
+  - uid: 801
     components:
     - type: Transform
       pos: 11.5,-12.5
       parent: 1
-  - uid: 801
+  - uid: 802
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,16.5
       parent: 1
-  - uid: 802
+  - uid: 803
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,7.5
       parent: 1
-  - uid: 803
+  - uid: 804
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6301,13 +6308,13 @@ entities:
       parent: 1
 - proto: PoweredlightGreen
   entities:
-  - uid: 804
+  - uid: 805
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,4.5
       parent: 1
-  - uid: 805
+  - uid: 806
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6315,12 +6322,12 @@ entities:
       parent: 1
 - proto: PoweredlightOrange
   entities:
-  - uid: 806
+  - uid: 807
     components:
     - type: Transform
       pos: 11.5,-7.5
       parent: 1
-  - uid: 807
+  - uid: 808
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6332,20 +6339,20 @@ entities:
     - type: Timer
 - proto: PoweredlightPink
   entities:
-  - uid: 808
+  - uid: 809
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 1
 - proto: PoweredlightRed
   entities:
-  - uid: 809
+  - uid: 810
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-0.5
       parent: 1
-  - uid: 810
+  - uid: 811
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6353,23 +6360,23 @@ entities:
       parent: 1
 - proto: Railing
   entities:
-  - uid: 811
+  - uid: 812
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,3.5
       parent: 1
-  - uid: 812
+  - uid: 813
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 813
+  - uid: 814
     components:
     - type: Transform
       pos: 14.5,0.5
       parent: 1
-  - uid: 814
+  - uid: 815
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6377,255 +6384,255 @@ entities:
       parent: 1
 - proto: RailingCorner
   entities:
-  - uid: 815
+  - uid: 816
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-12.5
       parent: 1
-  - uid: 816
+  - uid: 817
     components:
     - type: Transform
       pos: 5.5,-12.5
       parent: 1
 - proto: RandomSpawner
   entities:
-  - uid: 817
+  - uid: 818
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 818
+  - uid: 819
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 1
-  - uid: 819
+  - uid: 820
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 1
-  - uid: 820
+  - uid: 821
     components:
     - type: Transform
       pos: 5.5,-9.5
       parent: 1
-  - uid: 821
+  - uid: 822
     components:
     - type: Transform
       pos: 6.5,-8.5
       parent: 1
-  - uid: 822
+  - uid: 823
     components:
     - type: Transform
       pos: 12.5,-8.5
       parent: 1
-  - uid: 823
+  - uid: 824
     components:
     - type: Transform
       pos: 13.5,-9.5
       parent: 1
-  - uid: 824
+  - uid: 825
     components:
     - type: Transform
       pos: 8.5,-4.5
       parent: 1
-  - uid: 825
+  - uid: 826
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 1
-  - uid: 826
+  - uid: 827
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
-  - uid: 827
+  - uid: 828
     components:
     - type: Transform
       pos: 9.5,-5.5
       parent: 1
-  - uid: 828
+  - uid: 829
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
-  - uid: 829
+  - uid: 830
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 1
-  - uid: 830
+  - uid: 831
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 1
-  - uid: 831
+  - uid: 832
     components:
     - type: Transform
       pos: 4.5,7.5
       parent: 1
-  - uid: 832
+  - uid: 833
     components:
     - type: Transform
       pos: 8.5,5.5
       parent: 1
-  - uid: 833
+  - uid: 834
     components:
     - type: Transform
       pos: 12.5,1.5
       parent: 1
-  - uid: 834
+  - uid: 835
     components:
     - type: Transform
       pos: 12.5,2.5
       parent: 1
-  - uid: 835
+  - uid: 836
     components:
     - type: Transform
       pos: 10.5,3.5
       parent: 1
-  - uid: 836
+  - uid: 837
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 837
+  - uid: 838
     components:
     - type: Transform
       pos: 12.5,5.5
       parent: 1
-  - uid: 838
+  - uid: 839
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
-  - uid: 839
+  - uid: 840
     components:
     - type: Transform
       pos: 5.5,11.5
       parent: 1
-  - uid: 840
+  - uid: 841
     components:
     - type: Transform
       pos: 8.5,16.5
       parent: 1
-  - uid: 841
+  - uid: 842
     components:
     - type: Transform
       pos: 8.5,9.5
       parent: 1
-  - uid: 842
+  - uid: 843
     components:
     - type: Transform
       pos: 9.5,7.5
       parent: 1
-  - uid: 843
+  - uid: 844
     components:
     - type: Transform
       pos: 10.5,8.5
       parent: 1
-  - uid: 844
+  - uid: 845
     components:
     - type: Transform
       pos: 7.5,13.5
       parent: 1
-  - uid: 845
+  - uid: 846
     components:
     - type: Transform
       pos: 8.5,12.5
       parent: 1
-  - uid: 846
+  - uid: 847
     components:
     - type: Transform
       pos: 6.5,15.5
       parent: 1
-  - uid: 847
+  - uid: 848
     components:
     - type: Transform
       pos: 12.5,-7.5
       parent: 1
 - proto: ReinforcedPlasmaWindow
   entities:
-  - uid: 848
+  - uid: 849
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 849
+  - uid: 850
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 1
-  - uid: 850
+  - uid: 851
     components:
     - type: Transform
       pos: 3.5,11.5
       parent: 1
-  - uid: 851
+  - uid: 852
     components:
     - type: Transform
       pos: 4.5,13.5
       parent: 1
-  - uid: 852
+  - uid: 853
     components:
     - type: Transform
       pos: 5.5,15.5
       parent: 1
-  - uid: 853
+  - uid: 854
     components:
     - type: Transform
       pos: 9.5,15.5
       parent: 1
-  - uid: 854
+  - uid: 855
     components:
     - type: Transform
       pos: 10.5,13.5
       parent: 1
-  - uid: 855
+  - uid: 856
     components:
     - type: Transform
       pos: 12.5,8.5
       parent: 1
-  - uid: 856
+  - uid: 857
     components:
     - type: Transform
       pos: 12.5,7.5
       parent: 1
-  - uid: 857
+  - uid: 858
     components:
     - type: Transform
       pos: 13.5,5.5
       parent: 1
 - proto: SalvageTechfabNF
   entities:
-  - uid: 858
+  - uid: 859
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 1
 - proto: ScrapProcessor
   entities:
-  - uid: 859
+  - uid: 860
     components:
     - type: Transform
       pos: 8.5,5.5
       parent: 1
 - proto: ShuttersNormal
   entities:
-  - uid: 860
+  - uid: 861
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-8.5
       parent: 1
-  - uid: 861
+  - uid: 862
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-10.5
       parent: 1
-  - uid: 862
+  - uid: 863
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6633,116 +6640,116 @@ entities:
       parent: 1
 - proto: ShuttersNormalOpen
   entities:
-  - uid: 863
+  - uid: 864
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 864
+  - uid: 865
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
-  - uid: 865
+  - uid: 866
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 1
-  - uid: 866
+  - uid: 867
     components:
     - type: Transform
       pos: 8.5,-1.5
       parent: 1
-  - uid: 867
-    components:
-    - type: Transform
-      pos: 9.5,-1.5
-      parent: 1
   - uid: 868
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,15.5
+      pos: 9.5,-1.5
       parent: 1
   - uid: 869
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 4.5,13.5
+      pos: 5.5,15.5
       parent: 1
   - uid: 870
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,15.5
+      rot: 1.5707963267948966 rad
+      pos: 4.5,13.5
       parent: 1
   - uid: 871
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 10.5,13.5
+      pos: 9.5,15.5
       parent: 1
   - uid: 872
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,11.5
+      rot: -1.5707963267948966 rad
+      pos: 10.5,13.5
       parent: 1
   - uid: 873
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,10.5
+      pos: 3.5,11.5
       parent: 1
   - uid: 874
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,8.5
+      rot: 1.5707963267948966 rad
+      pos: 3.5,10.5
       parent: 1
   - uid: 875
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 12.5,7.5
+      pos: 12.5,8.5
       parent: 1
   - uid: 876
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 13.5,5.5
+      pos: 12.5,7.5
       parent: 1
   - uid: 877
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,5.5
+      rot: -1.5707963267948966 rad
+      pos: 13.5,5.5
       parent: 1
   - uid: 878
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,-4.5
+      pos: 1.5,5.5
       parent: 1
   - uid: 879
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 880
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-4.5
       parent: 1
-  - uid: 880
+  - uid: 881
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-10.5
       parent: 1
-  - uid: 881
+  - uid: 882
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-9.5
       parent: 1
-  - uid: 882
+  - uid: 883
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6750,7 +6757,7 @@ entities:
       parent: 1
 - proto: SignalButton
   entities:
-  - uid: 883
+  - uid: 884
     components:
     - type: MetaData
       name: Docking Bay Blast Doors (signal button)
@@ -6775,7 +6782,7 @@ entities:
       currentLabel: Docking Bay Blast Doors
     - type: NameModifier
       baseName: signal button
-  - uid: 884
+  - uid: 885
     components:
     - type: MetaData
       name: Docking Bay Window Shutters (signal button)
@@ -6785,6 +6792,9 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
+        872:
+        - - Pressed
+          - Toggle
         871:
         - - Pressed
           - Toggle
@@ -6794,16 +6804,13 @@ entities:
         869:
         - - Pressed
           - Toggle
-        868:
-        - - Pressed
-          - Toggle
     - type: Fixtures
       fixtures: {}
     - type: Label
       currentLabel: Docking Bay Window Shutters
     - type: NameModifier
       baseName: signal button
-  - uid: 885
+  - uid: 886
     components:
     - type: MetaData
       name: East Lounge Window Shutters (signal button)
@@ -6813,10 +6820,10 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        874:
+        875:
         - - Pressed
           - Toggle
-        875:
+        876:
         - - Pressed
           - Toggle
     - type: Fixtures
@@ -6825,30 +6832,12 @@ entities:
       currentLabel: East Lounge Window Shutters
     - type: NameModifier
       baseName: signal button
-  - uid: 886
+  - uid: 887
     components:
     - type: MetaData
       name: East Bay Window Shutter (signal button)
     - type: Transform
       pos: 11.5,6.5
-      parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        876:
-        - - Pressed
-          - Toggle
-    - type: Fixtures
-      fixtures: {}
-    - type: Label
-      currentLabel: East Bay Window Shutter
-    - type: NameModifier
-      baseName: signal button
-  - uid: 887
-    components:
-    - type: MetaData
-      name: West Bay Window Shutter (signal button)
-    - type: Transform
-      pos: 3.5,6.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
@@ -6858,10 +6847,28 @@ entities:
     - type: Fixtures
       fixtures: {}
     - type: Label
-      currentLabel: West Bay Window Shutter
+      currentLabel: East Bay Window Shutter
     - type: NameModifier
       baseName: signal button
   - uid: 888
+    components:
+    - type: MetaData
+      name: West Bay Window Shutter (signal button)
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        878:
+        - - Pressed
+          - Toggle
+    - type: Fixtures
+      fixtures: {}
+    - type: Label
+      currentLabel: West Bay Window Shutter
+    - type: NameModifier
+      baseName: signal button
+  - uid: 889
     components:
     - type: MetaData
       name: Command Center Door Bolts (signal button)
@@ -6886,7 +6893,7 @@ entities:
       currentLabel: Command Center Door Bolts
     - type: NameModifier
       baseName: signal button
-  - uid: 889
+  - uid: 890
     components:
     - type: MetaData
       name: West Bar WIndow Shutters (signal button)
@@ -6896,13 +6903,13 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        880:
-        - - Pressed
-          - Toggle
         881:
         - - Pressed
           - Toggle
         882:
+        - - Pressed
+          - Toggle
+        883:
         - - Pressed
           - Toggle
     - type: Fixtures
@@ -6911,7 +6918,7 @@ entities:
       currentLabel: West Bar WIndow Shutters
     - type: NameModifier
       baseName: signal button
-  - uid: 890
+  - uid: 891
     components:
     - type: MetaData
       name: West Bay Blast Doors (signal button)
@@ -6939,7 +6946,7 @@ entities:
       currentLabel: West Bay Blast Doors
     - type: NameModifier
       baseName: signal button
-  - uid: 891
+  - uid: 892
     components:
     - type: MetaData
       name: East Bay Blast Doors (signal button)
@@ -6967,7 +6974,7 @@ entities:
       currentLabel: East Bay Blast Doors
     - type: NameModifier
       baseName: signal button
-  - uid: 892
+  - uid: 893
     components:
     - type: MetaData
       name: Sout Blast Doors (signal button)
@@ -6992,7 +6999,7 @@ entities:
       currentLabel: Sout Blast Doors
     - type: NameModifier
       baseName: signal button
-  - uid: 893
+  - uid: 894
     components:
     - type: MetaData
       name: Command Center Window Shutters (signal button)
@@ -7002,10 +7009,13 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        867:
+        868:
         - - Pressed
           - Toggle
-        879:
+        880:
+        - - Pressed
+          - Toggle
+        867:
         - - Pressed
           - Toggle
         866:
@@ -7017,10 +7027,7 @@ entities:
         864:
         - - Pressed
           - Toggle
-        863:
-        - - Pressed
-          - Toggle
-        878:
+        879:
         - - Pressed
           - Toggle
     - type: Fixtures
@@ -7029,7 +7036,7 @@ entities:
       currentLabel: Command Center Window Shutters
     - type: NameModifier
       baseName: signal button
-  - uid: 894
+  - uid: 895
     components:
     - type: MetaData
       name: West Dorm Window Shutters (signal button)
@@ -7039,10 +7046,10 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        873:
+        874:
         - - Pressed
           - Toggle
-        872:
+        873:
         - - Pressed
           - Toggle
     - type: Fixtures
@@ -7051,7 +7058,7 @@ entities:
       currentLabel: West Dorm Window Shutters
     - type: NameModifier
       baseName: signal button
-  - uid: 895
+  - uid: 896
     components:
     - type: MetaData
       name: East Engineering Bay WIndow Shutters (signal button)
@@ -7060,13 +7067,13 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        860:
+        861:
+        - - Pressed
+          - Toggle
+        863:
         - - Pressed
           - Toggle
         862:
-        - - Pressed
-          - Toggle
-        861:
         - - Pressed
           - Toggle
     - type: Fixtures
@@ -7075,7 +7082,7 @@ entities:
       currentLabel: East Engineering Bay WIndow Shutters
     - type: NameModifier
       baseName: signal button
-  - uid: 896
+  - uid: 897
     components:
     - type: MetaData
       name: East Bay Blast Doors (signal button)
@@ -7103,7 +7110,7 @@ entities:
       currentLabel: East Bay Blast Doors
     - type: NameModifier
       baseName: signal button
-  - uid: 897
+  - uid: 898
     components:
     - type: MetaData
       name: West Bay Blast Doors (signal button)
@@ -7133,7 +7140,7 @@ entities:
       baseName: signal button
 - proto: SignBar
   entities:
-  - uid: 898
+  - uid: 899
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7143,7 +7150,7 @@ entities:
       fixtures: {}
 - proto: SignDirectionalSalvage
   entities:
-  - uid: 899
+  - uid: 900
     components:
     - type: Transform
       pos: 9.5,16.5
@@ -7152,7 +7159,7 @@ entities:
       fixtures: {}
 - proto: SignEngineering
   entities:
-  - uid: 900
+  - uid: 901
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7162,7 +7169,7 @@ entities:
       fixtures: {}
 - proto: SignLastIdiot
   entities:
-  - uid: 901
+  - uid: 902
     components:
     - type: Transform
       pos: 9.5,6.5
@@ -7171,7 +7178,7 @@ entities:
       fixtures: {}
 - proto: SignSalvage
   entities:
-  - uid: 902
+  - uid: 903
     components:
     - type: Transform
       pos: 5.5,6.5
@@ -7180,7 +7187,7 @@ entities:
       fixtures: {}
 - proto: SinkWide
   entities:
-  - uid: 903
+  - uid: 904
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7188,23 +7195,23 @@ entities:
       parent: 1
 - proto: SmallThruster
   entities:
-  - uid: 904
+  - uid: 905
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 905
+  - uid: 906
     components:
     - type: Transform
       pos: 13.5,7.5
       parent: 1
-  - uid: 906
+  - uid: 907
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,-2.5
       parent: 1
-  - uid: 907
+  - uid: 908
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7212,47 +7219,47 @@ entities:
       parent: 1
 - proto: SMESBasic
   entities:
-  - uid: 908
+  - uid: 909
     components:
     - type: Transform
       pos: 10.5,-10.5
       parent: 1
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 909
+  - uid: 910
     components:
     - type: Transform
       pos: 10.5,7.5
       parent: 1
-  - uid: 910
+  - uid: 911
     components:
     - type: Transform
       pos: 11.5,7.5
       parent: 1
-  - uid: 911
+  - uid: 912
     components:
     - type: Transform
       pos: 11.5,8.5
       parent: 1
-  - uid: 912
+  - uid: 913
     components:
     - type: Transform
       pos: 6.5,14.5
       parent: 1
-  - uid: 913
+  - uid: 914
     components:
     - type: Transform
       pos: 8.5,14.5
       parent: 1
 - proto: SteelBench
   entities:
-  - uid: 914
+  - uid: 915
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,14.5
       parent: 1
-  - uid: 915
+  - uid: 916
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7260,19 +7267,19 @@ entities:
       parent: 1
 - proto: StoolBar
   entities:
-  - uid: 916
+  - uid: 917
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-9.5
       parent: 1
-  - uid: 917
+  - uid: 918
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-10.5
       parent: 1
-  - uid: 918
+  - uid: 919
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7280,28 +7287,28 @@ entities:
       parent: 1
 - proto: StructureMeleeWeaponRackWallmountedSalvage
   entities:
-  - uid: 919
+  - uid: 920
     components:
     - type: Transform
       pos: 4.5,9.5
       parent: 1
 - proto: SubstationBasic
   entities:
-  - uid: 920
+  - uid: 921
     components:
     - type: Transform
       pos: 9.5,-10.5
       parent: 1
 - proto: Table
   entities:
-  - uid: 921
+  - uid: 922
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
 - proto: TableFolding
   entities:
-  - uid: 922
+  - uid: 923
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7346,25 +7353,25 @@ entities:
       folded: True
 - proto: TableReinforced
   entities:
-  - uid: 923
+  - uid: 924
     components:
     - type: Transform
       pos: 10.5,-4.5
       parent: 1
-  - uid: 924
+  - uid: 925
     components:
     - type: Transform
       pos: 10.5,-5.5
       parent: 1
 - proto: TableWood
   entities:
-  - uid: 925
+  - uid: 926
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,7.5
       parent: 1
-  - uid: 926
+  - uid: 927
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7372,31 +7379,31 @@ entities:
       parent: 1
 - proto: TableWoodReinforced
   entities:
-  - uid: 927
+  - uid: 928
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-8.5
       parent: 1
-  - uid: 928
+  - uid: 929
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-9.5
       parent: 1
-  - uid: 929
+  - uid: 930
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-10.5
       parent: 1
-  - uid: 930
+  - uid: 931
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-9.5
       parent: 1
-  - uid: 931
+  - uid: 932
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7404,66 +7411,66 @@ entities:
       parent: 1
 - proto: TelecomServerFilledShuttle
   entities:
-  - uid: 932
+  - uid: 933
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
 - proto: Thruster
   entities:
-  - uid: 933
+  - uid: 934
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-12.5
       parent: 1
-  - uid: 934
+  - uid: 935
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-12.5
       parent: 1
-  - uid: 935
+  - uid: 936
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-5.5
       parent: 1
-  - uid: 936
+  - uid: 937
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-5.5
       parent: 1
-  - uid: 937
+  - uid: 938
     components:
     - type: Transform
       pos: 4.5,15.5
       parent: 1
-  - uid: 938
-    components:
-    - type: Transform
-      pos: 10.5,15.5
-      parent: 1
   - uid: 939
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-12.5
+      pos: 10.5,15.5
       parent: 1
   - uid: 940
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,-12.5
+      pos: 4.5,-12.5
       parent: 1
   - uid: 941
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 10.5,-12.5
+      pos: 2.5,-12.5
       parent: 1
   - uid: 942
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-12.5
+      parent: 1
+  - uid: 943
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7471,14 +7478,14 @@ entities:
       parent: 1
 - proto: ToyRipley
   entities:
-  - uid: 943
+  - uid: 944
     components:
     - type: Transform
       pos: 5.4700966,5.499836
       parent: 1
 - proto: TransFlag
   entities:
-  - uid: 944
+  - uid: 945
     components:
     - type: Transform
       pos: 5.5,12.5
@@ -7487,21 +7494,21 @@ entities:
       fixtures: {}
 - proto: VendingMachineBooze
   entities:
-  - uid: 945
+  - uid: 946
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 946
+  - uid: 947
     components:
     - type: Transform
       pos: 5.5,13.5
       parent: 1
 - proto: WallmountTelevisionFrame
   entities:
-  - uid: 947
+  - uid: 948
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7511,331 +7518,331 @@ entities:
       fixtures: {}
 - proto: WallReinforced
   entities:
-  - uid: 948
+  - uid: 949
     components:
     - type: Transform
       pos: 4.5,14.5
       parent: 1
-  - uid: 949
+  - uid: 950
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 950
+  - uid: 951
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 951
+  - uid: 952
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 1
-  - uid: 952
+  - uid: 953
     components:
     - type: Transform
       pos: 12.5,-6.5
       parent: 1
-  - uid: 953
+  - uid: 954
     components:
     - type: Transform
       pos: 11.5,-5.5
       parent: 1
-  - uid: 954
+  - uid: 955
     components:
     - type: Transform
       pos: 13.5,-7.5
       parent: 1
-  - uid: 955
+  - uid: 956
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 956
+  - uid: 957
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 957
+  - uid: 958
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
-  - uid: 958
+  - uid: 959
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 959
+  - uid: 960
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 960
+  - uid: 961
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 961
+  - uid: 962
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 962
+  - uid: 963
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 963
+  - uid: 964
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 964
+  - uid: 965
     components:
     - type: Transform
       pos: 4.5,12.5
       parent: 1
-  - uid: 965
+  - uid: 966
     components:
     - type: Transform
       pos: 9.5,16.5
       parent: 1
-  - uid: 966
+  - uid: 967
     components:
     - type: Transform
       pos: 10.5,12.5
       parent: 1
-  - uid: 967
+  - uid: 968
     components:
     - type: Transform
       pos: 12.5,6.5
       parent: 1
-  - uid: 968
+  - uid: 969
     components:
     - type: Transform
       pos: 13.5,4.5
       parent: 1
-  - uid: 969
+  - uid: 970
     components:
     - type: Transform
       pos: 11.5,9.5
       parent: 1
-  - uid: 970
+  - uid: 971
     components:
     - type: Transform
       pos: 11.5,10.5
       parent: 1
-  - uid: 971
+  - uid: 972
     components:
     - type: Transform
       pos: 11.5,-6.5
       parent: 1
-  - uid: 972
+  - uid: 973
     components:
     - type: Transform
       pos: 13.5,6.5
       parent: 1
-  - uid: 973
+  - uid: 974
     components:
     - type: Transform
       pos: 12.5,-1.5
       parent: 1
-  - uid: 974
+  - uid: 975
     components:
     - type: Transform
       pos: 12.5,-2.5
       parent: 1
-  - uid: 975
+  - uid: 976
     components:
     - type: Transform
       pos: 11.5,-3.5
       parent: 1
-  - uid: 976
+  - uid: 977
     components:
     - type: Transform
       pos: 7.5,-6.5
       parent: 1
-  - uid: 977
+  - uid: 978
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
-  - uid: 978
+  - uid: 979
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
-  - uid: 979
+  - uid: 980
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 1
-  - uid: 980
+  - uid: 981
     components:
     - type: Transform
       pos: 3.5,-11.5
       parent: 1
-  - uid: 981
+  - uid: 982
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 1
-  - uid: 982
+  - uid: 983
     components:
     - type: Transform
       pos: 9.5,-11.5
       parent: 1
-  - uid: 983
+  - uid: 984
     components:
     - type: Transform
       pos: 12.5,-11.5
       parent: 1
-  - uid: 984
+  - uid: 985
     components:
     - type: Transform
       pos: 13.5,-11.5
       parent: 1
-  - uid: 985
+  - uid: 986
     components:
     - type: Transform
       pos: 10.5,-6.5
       parent: 1
 - proto: WallReinforcedDiagonal
   entities:
-  - uid: 986
+  - uid: 987
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,14.5
       parent: 1
-  - uid: 987
+  - uid: 988
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,14.5
       parent: 1
-  - uid: 988
+  - uid: 989
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
-  - uid: 989
-    components:
-    - type: Transform
-      pos: 1.5,-6.5
-      parent: 1
   - uid: 990
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,-6.5
+      pos: 1.5,-6.5
       parent: 1
   - uid: 991
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 14.5,-7.5
+      pos: 13.5,-6.5
       parent: 1
   - uid: 992
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-3.5
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-7.5
       parent: 1
   - uid: 993
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 1.5,-1.5
+      pos: 2.5,-3.5
       parent: 1
   - uid: 994
     components:
     - type: Transform
-      pos: 2.5,9.5
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-1.5
       parent: 1
   - uid: 995
     components:
     - type: Transform
-      pos: 3.5,12.5
+      pos: 2.5,9.5
       parent: 1
   - uid: 996
     components:
     - type: Transform
-      pos: 5.5,17.5
+      pos: 3.5,12.5
       parent: 1
   - uid: 997
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,17.5
+      pos: 5.5,17.5
       parent: 1
   - uid: 998
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 12.5,9.5
+      pos: 9.5,17.5
       parent: 1
   - uid: 999
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 13.5,-1.5
+      rot: -1.5707963267948966 rad
+      pos: 12.5,9.5
       parent: 1
   - uid: 1000
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 12.5,-3.5
+      pos: 13.5,-1.5
       parent: 1
   - uid: 1001
     components:
     - type: Transform
-      pos: 4.5,-1.5
+      rot: 3.141592653589793 rad
+      pos: 12.5,-3.5
       parent: 1
   - uid: 1002
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 1003
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-1.5
       parent: 1
-  - uid: 1003
+  - uid: 1004
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-3.5
       parent: 1
-  - uid: 1004
+  - uid: 1005
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-3.5
       parent: 1
-  - uid: 1005
+  - uid: 1006
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,12.5
       parent: 1
-  - uid: 1006
+  - uid: 1007
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-11.5
       parent: 1
-  - uid: 1007
+  - uid: 1008
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-12.5
       parent: 1
-  - uid: 1008
+  - uid: 1009
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,-11.5
       parent: 1
-  - uid: 1009
+  - uid: 1010
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7843,184 +7850,184 @@ entities:
       parent: 1
 - proto: WallReinforcedRust
   entities:
-  - uid: 1010
+  - uid: 1011
     components:
     - type: Transform
       pos: 10.5,14.5
       parent: 1
-  - uid: 1011
+  - uid: 1012
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 1012
+  - uid: 1013
     components:
     - type: Transform
       pos: 5.5,16.5
       parent: 1
-  - uid: 1013
+  - uid: 1014
     components:
     - type: Transform
       pos: 11.5,11.5
       parent: 1
-  - uid: 1014
+  - uid: 1015
     components:
     - type: Transform
       pos: 13.5,-0.5
       parent: 1
-  - uid: 1015
+  - uid: 1016
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
-  - uid: 1016
+  - uid: 1017
     components:
     - type: Transform
       pos: 6.5,-6.5
       parent: 1
-  - uid: 1017
+  - uid: 1018
     components:
     - type: Transform
       pos: 8.5,-6.5
       parent: 1
-  - uid: 1018
+  - uid: 1019
     components:
     - type: Transform
       pos: 5.5,-11.5
       parent: 1
-  - uid: 1019
+  - uid: 1020
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 1
-  - uid: 1020
+  - uid: 1021
     components:
     - type: Transform
       pos: 11.5,-11.5
       parent: 1
-  - uid: 1021
+  - uid: 1022
     components:
     - type: Transform
       pos: 10.5,-11.5
       parent: 1
 - proto: WallSolid
   entities:
-  - uid: 1022
+  - uid: 1023
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 1
-  - uid: 1023
+  - uid: 1024
     components:
     - type: Transform
       pos: 5.5,12.5
       parent: 1
-  - uid: 1024
+  - uid: 1025
     components:
     - type: Transform
       pos: 6.5,11.5
       parent: 1
-  - uid: 1025
+  - uid: 1026
     components:
     - type: Transform
       pos: 7.5,11.5
       parent: 1
-  - uid: 1026
+  - uid: 1027
     components:
     - type: Transform
       pos: 10.5,11.5
       parent: 1
-  - uid: 1027
+  - uid: 1028
     components:
     - type: Transform
       pos: 6.5,9.5
       parent: 1
-  - uid: 1028
+  - uid: 1029
     components:
     - type: Transform
       pos: 5.5,9.5
       parent: 1
-  - uid: 1029
+  - uid: 1030
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 1
-  - uid: 1030
+  - uid: 1031
     components:
     - type: Transform
       pos: 10.5,6.5
       parent: 1
-  - uid: 1031
+  - uid: 1032
     components:
     - type: Transform
       pos: 9.5,6.5
       parent: 1
-  - uid: 1032
+  - uid: 1033
     components:
     - type: Transform
       pos: 8.5,6.5
       parent: 1
 - proto: WallSolidRust
   entities:
-  - uid: 1033
+  - uid: 1034
     components:
     - type: Transform
       pos: 8.5,11.5
       parent: 1
-  - uid: 1034
+  - uid: 1035
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 1
-  - uid: 1035
+  - uid: 1036
     components:
     - type: Transform
       pos: 6.5,7.5
       parent: 1
-  - uid: 1036
+  - uid: 1037
     components:
     - type: Transform
       pos: 6.5,8.5
       parent: 1
-  - uid: 1037
+  - uid: 1038
     components:
     - type: Transform
       pos: 4.5,9.5
       parent: 1
-  - uid: 1038
+  - uid: 1039
     components:
     - type: Transform
       pos: 11.5,6.5
       parent: 1
-  - uid: 1039
+  - uid: 1040
     components:
     - type: Transform
       pos: 6.5,12.5
       parent: 1
 - proto: WallWeaponCapacitorRecharger
   entities:
-  - uid: 1040
+  - uid: 1041
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 1041
+  - uid: 1042
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,6.5
       parent: 1
-  - uid: 1042
+  - uid: 1043
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 1
-  - uid: 1043
+  - uid: 1044
     components:
     - type: Transform
       pos: 8.5,6.5
       parent: 1
-  - uid: 1044
+  - uid: 1045
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8028,7 +8035,7 @@ entities:
       parent: 1
 - proto: WarpPoint
   entities:
-  - uid: 1045
+  - uid: 1046
     components:
     - type: Transform
       pos: 7.5,1.5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added Bluespace Holopad to the Behir, edited Generator output to match new power draw requirements.

## Why / Balance
I am very smart and forgot to add a Bluespace Holopad to the ship. 

## Technical details
Added Bluespace Holopad to Behir Command Bay
Changed generator output from 33kw to 34kw

## How to test
purchase ship! <3

## Media
<img width="537" height="370" alt="image" src="https://github.com/user-attachments/assets/6bb0c86c-20d8-46eb-abec-b51c073095cb" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Added Bluespace Holopad, increased mapinit generator output to match new requirements.

**Changelog**
:cl:
- add: Bluespace Holopad
- tweak: Generator output