### PR TITLE
Add 'Thump' emote for Feroxi species

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/feroxi.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/feroxi.yml
@@ -21,7 +21,7 @@
   - type: Speech
     speechSounds: Tenor
     speechVerb: Feroxi
-    allowedEmotes: ['Gnash']
+    allowedEmotes: ['Gnash', 'Thump'] #Wayfarer: Add Thump
   - type: Vocal
     sounds:
       Male: MaleFeroxi

--- a/Resources/Prototypes/_DV/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_DV/Voice/speech_emote_sounds.yml
@@ -320,6 +320,8 @@
       collection: MaleYawn
     Gnash:
       collection: FeroxiGnashes
+    Thump: #Wayfarer: Tail thump
+      path: /Audio/Voice/Reptilian/reptilian_tailthump.ogg #Wayfarer: Tail thump
 
 - type: emoteSounds
   id: FemaleFeroxi
@@ -350,6 +352,8 @@
       collection: Weh
     Gnash:
       collection: FeroxiGnashes
+    Thump:
+      path: /Audio/Voice/Reptilian/reptilian_tailthump.ogg
 
 - type: emoteSounds
   id: UnisexChitinid

--- a/Resources/Prototypes/_DV/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_DV/Voice/speech_emote_sounds.yml
@@ -352,8 +352,8 @@
       collection: Weh
     Gnash:
       collection: FeroxiGnashes
-    Thump:
-      path: /Audio/Voice/Reptilian/reptilian_tailthump.ogg
+    Thump: #Wayfarer: Tail thump
+      path: /Audio/Voice/Reptilian/reptilian_tailthump.ogg #Wayfarer: Tail thump
 
 - type: emoteSounds
   id: UnisexChitinid


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added reptilian_tailthump emote to feroxi species: wired up the sound in both MaleFeroxi and FemaleFeroxi emote sounds, then added Thump to their emote wheel via allowedEmotes. Requested by Aliasen.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Feroxi can tail thump now
