### PR TITLE
Default Felinid Tail Fix

### DIFF
--- a/Resources/Locale/en-US/markings/felinid.ftl
+++ b/Resources/Locale/en-US/markings/felinid.ftl
@@ -3,6 +3,10 @@ marking-FelinidEarsBasic = [ Felinid ] Basic Ears
 marking-FelinidEarsBasic-basic_outer = [ Felinid ] Outer Ear
 marking-FelinidEarsBasic-basic_inner = [ Felinid ] Inner Ear
 
+marking-FelinidEarsDefault = [ Felinid ] Default Ears
+marking-FelinidEarsDefault-basic_outer = [ Felinid ] Outer Ear
+marking-FelinidEarsDefault-basic_inner = [ Felinid ] Inner Ear
+
 marking-FelinidEarsCurled = [ Felinid ] Curled Ears
 marking-FelinidEarsCurled-curled_outer = [ Felinid ] Outer Ear
 marking-FelinidEarsCurled-curled_inner = [ Felinid ] Inner Ear
@@ -36,6 +40,11 @@ marking-FelinidTailBasic = [ Felinid ] Basic Tail
 marking-FelinidTailBasic-basic_tail_tip = [ Felinid ] Tail Tip
 marking-FelinidTailBasic-basic_tail_stripes_even = [ Felinid ] Tail Stripes, Even
 marking-FelinidTailBasic-basic_tail_stripes_odd = [ Felinid ] Tail Stripes, Odd
+
+marking-FelinidTailDefault = [ Felinid ] Default Tail
+marking-FelinidTailDefault-basic_tail_tip = [ Felinid ] Tail Tip
+marking-FelinidTailDefault-basic_tail_stripes_even = [ Felinid ] Tail Stripes, Even
+marking-FelinidTailDefault-basic_tail_stripes_odd = [ Felinid ] Tail Stripes, Odd
 
 marking-FelinidTailBasicWithBow = [ Felinid ] Basic Tail with Bow
 marking-FelinidTailBasicWithBow-basic_tail_tip = [ Felinid ] Tail Tip

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Customization/Markings/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Customization/Markings/felinid.yml
@@ -4,18 +4,30 @@
   id: FelinidEarsBasic
   bodyPart: HeadTop
   markingCategory: HeadTop
-  # speciesRestriction: [Felinid] -WF
+  # speciesRestriction: [Felinid] # Wayfarer
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_ears.rsi
     state: basic_outer
   - sprite: Nyanotrasen/Mobs/Customization/felinid_ears.rsi
     state: basic_inner
 
+# Wayfarer: Alt Felinid Default Ears
+- type: marking
+  id: FelinidEarsDefault
+  bodyPart: HeadTop
+  markingCategory: HeadTop
+  sprites:
+  - sprite: Nyanotrasen/Mobs/Customization/felinid_ears.rsi
+    state: basic_outer
+  - sprite: Nyanotrasen/Mobs/Customization/felinid_ears.rsi
+    state: basic_inner
+# End Wayfarer
+
 - type: marking
   id: FelinidEarsCurled
   bodyPart: HeadTop
   markingCategory: HeadTop
-  # speciesRestriction: [Felinid] -WF
+  # speciesRestriction: [Felinid] # Wayfarer
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_ears.rsi
     state: curled_outer
@@ -26,7 +38,7 @@
   id: FelinidEarsDroopy
   bodyPart: HeadTop
   markingCategory: HeadTop
-  # speciesRestriction: [Felinid] -WF
+  # speciesRestriction: [Felinid] # Wayfarer
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_ears.rsi
     state: droopy_outer
@@ -37,7 +49,7 @@
   id: FelinidEarsFuzzy
   bodyPart: HeadTop
   markingCategory: HeadTop
-  # speciesRestriction: [Felinid] -WF
+  # speciesRestriction: [Felinid] # Wayfarer
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_ears.rsi
     state: basic_outer
@@ -48,7 +60,7 @@
   id: FelinidEarsStubby
   bodyPart: HeadTop
   markingCategory: HeadTop
-  # speciesRestriction: [Felinid] -WF
+  # speciesRestriction: [Felinid] # Wayfarer
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_ears.rsi
     state: stubby_outer
@@ -59,7 +71,7 @@
   id: FelinidEarsTall
   bodyPart: HeadTop
   markingCategory: HeadTop
-  # speciesRestriction: [Felinid] -WF
+  # speciesRestriction: [Felinid] # Wayfarer
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_ears.rsi
     state: tall_outer
@@ -72,7 +84,7 @@
   id: FelinidEarsTorn
   bodyPart: HeadTop
   markingCategory: HeadTop
-  # speciesRestriction: [Felinid] -WF
+  # speciesRestriction: [Felinid] # Wayfarer
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_ears.rsi
     state: torn_outer
@@ -83,7 +95,7 @@
   id: FelinidEarsWide
   bodyPart: HeadTop
   markingCategory: HeadTop
-  # speciesRestriction: [Felinid] -WF
+  # speciesRestriction: [Felinid] # Wayfarer
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_ears.rsi
     state: wide_outer
@@ -96,7 +108,7 @@
   id: FelinidTailBasic
   bodyPart: Tail
   markingCategory: Tail
-  # speciesRestriction: [Felinid] -WF
+  # speciesRestriction: [Felinid] # Wayfarer
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_tails.rsi
     state: basic_tail_tip
@@ -105,11 +117,25 @@
   - sprite: Nyanotrasen/Mobs/Customization/felinid_tails.rsi
     state: basic_tail_stripes_odd
 
+# Wayfarer: Alt Felinid Default Tail
+- type: marking
+  id: FelinidTailDefault
+  bodyPart: Tail
+  markingCategory: Tail
+  sprites:
+  - sprite: Nyanotrasen/Mobs/Customization/felinid_tails.rsi
+    state: basic_tail_tip
+  - sprite: Nyanotrasen/Mobs/Customization/felinid_tails.rsi
+    state: basic_tail_stripes_even
+  - sprite: Nyanotrasen/Mobs/Customization/felinid_tails.rsi
+    state: basic_tail_stripes_odd
+# End Wayfarer
+
 - type: marking
   id: FelinidTailBasicWithBow
   bodyPart: Tail
   markingCategory: Tail
-  # speciesRestriction: [Felinid] -WF
+  # speciesRestriction: [Felinid] # Wayfarer
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_tails.rsi
     state: basic_tail_tip
@@ -124,7 +150,7 @@
   id: FelinidTailBasicWithBell
   bodyPart: Tail
   markingCategory: Tail
-  # speciesRestriction: [Felinid] -WF
+  # speciesRestriction: [Felinid] # Wayfarer
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_tails.rsi
     state: basic_tail_tip
@@ -139,7 +165,7 @@
   id: FelinidTailBasicWithBowAndBell
   bodyPart: Tail
   markingCategory: Tail
-  # speciesRestriction: [Felinid] -WF
+  # speciesRestriction: [Felinid] # Wayfarer
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_tails.rsi
     state: basic_tail_tip

--- a/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
@@ -20,11 +20,11 @@
     Tail:
       points: 32 # Wayfarer: 1<32
       required: true
-      defaultMarkings: [ FelinidTailBasic ]
+      defaultMarkings: [ FelinidTailDefault ] # Wayfarer: FelinidTailBasic<FelinidTailDefault
     HeadTop:
       points: 32 # Wayfarer: 1<32
       required: true
-      defaultMarkings: [ FelinidEarsBasic ]
+      defaultMarkings: [ FelinidEarsDefault ] # Wayfarer: FelinidEarsBasic<FelinidEarsDefault
     Chest:
       points: 32 # Wayfarer: 1<32
       required: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds two new default marking prototypes to the Felinid marking set, so that the basic tail and ears can be recolored.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Closes https://github.com/project-wayfarer/wayfarer-14/issues/1149
The default ears and tail could not be recolored.
## Technical details
<!-- Summary of code changes for easier review. -->
Changes default prototype on species to use the defaults instead.
## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Test changing marking colors on non-default basic tail and ears.