### PR TITLE
Changes safezone rules around Dusk

### DIFF
--- a/Resources/ServerInfo/Rules.txt
+++ b/Resources/ServerInfo/Rules.txt
@@ -57,7 +57,6 @@
 	• Non-pirates may not assist or work with pirate crews, examples are such as watching mass scanners and tipping them off who to attack, pretending to be hostages, or knowingly funding the pirates for equipment/ships.
 
 [color=#a4885c][head=3]8. Follow Station Safezone Guidelines[/head][/color]
-	• [color=#ff0000] The immediate 200 meters around the Frontier and the Frontier itself is considered a safe zone and absolutely no antag activity or griefing is permitted within that zone.[/color] This includes but is not limited to destruction, modification, removal, or otherwise restriction of use of any machine or device designed for public use, and the structure of the station itself.
 	• For any non-antagonistic or roleplay modifications of the station, Station Rep's approval is always required.
 	• Fights and confrontations is completely disallowed on the safezone such as shooting, attacking or any forms of harm.
 	• Pirate actions may not begin on the Frontier. This includes stowing away while at the Frontier with intentions to steal the ship, outright stealing the ship or its cargo from the dock, selling someone else’s ship you hadn’t pirated outside the safe zone, or joining the crew under false pretenses with the intention to mutiny and take the ship.

--- a/Resources/ServerInfo/_WF/Guidebook/Rules/D1.xml
+++ b/Resources/ServerInfo/_WF/Guidebook/Rules/D1.xml
@@ -6,7 +6,7 @@
  - Medical Dispatch and Edison are lite-safe zones, and you are not to be engaging in PvP or griefing.  Although you can conduct antagonistic activity in these locations.
  - The CGP Outpost is a safe zone, you cannot engage in PvP, griefing or outlaw activity, although outlaws can aHelp to request that this be lifted.  This will be confirmed with CGP so that both sides can prepare.
  - Perdition is a safe zone, you cannot engage in PvP, griefing or CGP activity, although CGP can aHelp to request that this be lifted. This will be confirmed with Outlaws so that both sides can prepare.
- - Characters fleeing to a safe zone are to be disengaged, unless they are CGP fleeing to Quanteey or an Outlaw fleeing to Perdition.  In which case you can pursue them and the safezone is briefly lifted for that scene.
+ - Characters fleeing to a safe zone are to be disengaged, unless they are CGP fleeing to the outpost or an Outlaw fleeing to Perdition.  In which case you can pursue them and the safezone is briefly lifted for that scene.
  - Dangerous research on anomalies or artifacts are not to be done within Safe Zones or Lite-Safe Zones
 
 </Document>

--- a/Resources/ServerInfo/_WF/Guidebook/Rules/D1.xml
+++ b/Resources/ServerInfo/_WF/Guidebook/Rules/D1.xml
@@ -1,7 +1,8 @@
 <Document>
 # Rule D1: Safe Zones
 
- - Dusk Station and 200 meters around Dusk, is a safe zone.  You are not to be engaging in any PvP, griefing or other antagonistic activity within this space.
+ - Dusk Station itself is protected from large scale encounters. Any encounter on Dusk must be kept limited in scale with appropriate lead up. Shootouts on Dusk are automatically marked as red alert worthy.
+ - Any departmental or access locked space is considered protected, and must be ahelped prior to request raid permissions. Raid permission will only be granted for occasions when somebody is present to respond. This includes but is not limited to; The bridge, atmospherics, engineering, mail, medical, and the CGP office.
  - Medical Dispatch and Edison are lite-safe zones, and you are not to be engaging in PvP or griefing.  Although you can conduct antagonistic activity in these locations.
  - The CGP Outpost is a safe zone, you cannot engage in PvP, griefing or outlaw activity, although outlaws can aHelp to request that this be lifted.  This will be confirmed with CGP so that both sides can prepare.
  - Perdition is a safe zone, you cannot engage in PvP, griefing or CGP activity, although CGP can aHelp to request that this be lifted. This will be confirmed with Outlaws so that both sides can prepare.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed Dusk safezone rules. Removed references to 200 meters around Dusk. Added raid protection to departmental areas.

## Why / Balance
Allow fights on Dusk within reason. Safezone often forgotten.

## Technical details
Changed D1.xml and Rules.txt

## How to test
Load game. Read rules.

## Media
None

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:

- remove: Removed Dusk's safezone. Departmental areas now require raid permissions.


