### PR TITLE
Topical Healing Limit System

### DIFF
--- a/Content.Shared/Medical/Healing/HealingSystem.cs
+++ b/Content.Shared/Medical/Healing/HealingSystem.cs
@@ -18,7 +18,7 @@ using Robust.Shared.Audio.Systems;
 
 namespace Content.Shared.Medical.Healing;
 
-public sealed class HealingSystem : EntitySystem
+public sealed partial class HealingSystem : EntitySystem // Wayfarer: Added Partial
 {
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
@@ -198,6 +198,14 @@ public sealed class HealingSystem : EntitySystem
             _popupSystem.PopupClient(Loc.GetString("medical-item-cant-use", ("item", healing.Owner)), healing, user);
             return false;
         }
+
+        // Wayfarer: block healing if the damage is a big ouch owie (too severe)
+        if (IsHealingThresholdExceeded(healing, target!))
+        {
+            _popupSystem.PopupClient(Loc.GetString("medical-item-too-severe", ("item", healing.Owner)), healing, user);
+            return false;
+        }
+        // End Wayfarer
 
         _audio.PlayPredicted(healing.Comp.HealingBeginSound, healing, user);
 

--- a/Content.Shared/_WF/Medical/Healing/HealingComponent.cs
+++ b/Content.Shared/_WF/Medical/Healing/HealingComponent.cs
@@ -1,0 +1,13 @@
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared.Medical.Healing;
+
+public sealed partial class HealingComponent
+{
+    /// <summary>
+    /// Optional per-group damage thresholds, if the target's total damage in a group equals or exceeds this value, that means you'll need alternative means to heal them.
+    /// Keys are damage group prototype ids ("Brute", "Burn", etc) or individual damage type ids. The system only currently allows for one or the other, otherwise there may be issues.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Dictionary<string, FixedPoint2>? MaxHealableDamage;
+}

--- a/Content.Shared/_WF/Medical/Healing/HealingSystem.cs
+++ b/Content.Shared/_WF/Medical/Healing/HealingSystem.cs
@@ -1,0 +1,33 @@
+using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Medical.Healing;
+
+public sealed partial class HealingSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+
+    /// <summary>
+    /// checks if the target's damage exceeds the item's MaxHealableDamage thresholds, aka, the big ouch
+    /// </summary>
+    private bool IsHealingThresholdExceeded(Entity<HealingComponent> healing, Entity<DamageableComponent> target)
+    {
+        if (healing.Comp.MaxHealableDamage is not { } thresholds)
+            return false;
+
+        foreach (var (key, max) in thresholds)
+        {
+            // First, try as a specific damage type, like heat, slash and etc.
+            if (target.Comp.Damage.DamageDict.TryGetValue(key, out var typeDamage) && typeDamage >= max)
+                return true;
+
+            // If not a damage type, try as a damage group, like brute and burn... The generalized approach.
+            if (_proto.TryIndex<DamageGroupPrototype>(key, out var groupProto) &&
+                target.Comp.Damage.TryGetDamageInGroup(groupProto, out var groupTotal) &&
+                groupTotal >= max)
+                return true;
+        }
+        return false;
+    }
+}

--- a/Resources/Locale/en-US/_WF/medical/components/healing-component.ftl
+++ b/Resources/Locale/en-US/_WF/medical/components/healing-component.ftl
@@ -1,0 +1,1 @@
+medical-item-too-severe = The damage is too severe for the {$item} to handle.

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -46,6 +46,10 @@
       params:
         volume: 1.0
         variation: 0.125
+    # Wayfarer Start
+    maxHealableDamage:
+      Burn: 150
+    # End Wayfarer
   - type: Stack
     stackType: Ointment
     count: 10
@@ -94,6 +98,10 @@
       params:
         volume: 1.0
         variation: 0.125
+    # Wayfarer Start
+    maxHealableDamage:
+      Burn: 300
+    # End Wayfarer
   - type: Stack
     stackType: RegenerativeMesh
     count: 10
@@ -139,6 +147,10 @@
       params:
         volume: 1.0
         variation: 0.125
+    # Wayfarer Start
+    maxHealableDamage:
+      Brute: 150
+    # End Wayfarer
   - type: Stack
     stackType: Brutepack
     count: 10
@@ -186,6 +198,10 @@
       params:
         volume: 1.0
         variation: 0.125
+    # Wayfarer Start
+    maxHealableDamage:
+      Brute: 300
+    # End Wayfarer
   - type: Stack
     stackType: MedicatedSuture
     count: 10
@@ -316,6 +332,11 @@
       params:
         volume: 1.0
         variation: 0.125
+    # Wayfarer Start
+    maxHealableDamage:
+      Slash: 100
+      Piercing: 100
+    # End Wayfarer
   - type: Stack
     stackType: Gauze
     count: 10


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Per request, extends the healingsystem and healing component so that topicals can be limited in their ability to heal things.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Per request of Roy and Carrie, as part of a massive discussion involving the overuse of topicals. This is... A bandaid, and should probably be reverted when proper, thorough medical systems are in place.

With this change, basic topicals can only heal up to 150 damage of their overarching group (gauze being the exception as it's specialized to only heal slash and piercing, healing up to 100 of each) and advanced topicals can heal up to 300 damage of their group.
Bloodpacks were not touched.

## Technical details
So, I extended the healing component and systems and added both a new method and a datafield to them. This is responsible for checking if a topical has damage keys set to limit them from healing a target when it has more damage than X in a given key. The given key can either be the overarching group, or the individual damage types.

Should be simple enough, not intrusive, easy to revert.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Shoot/burn/maim an urist, try to heal them with topicals. Now try to heal them when they have damage above the caps.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="311" height="69" alt="image" src="https://github.com/user-attachments/assets/6560ff66-e389-49de-a8c2-9cf306c10926" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Topical Healing Damage Caps, per request.
