### PR TITLE
Reduces Hybrid Crossing Seedless Chance

### DIFF
--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -103,7 +103,7 @@ public sealed class MutationSystem : EntitySystem
 
         // Hybrids have a high chance of being seedless. Balances very
         // effective hybrid crossings.
-        if (a.Name != result.Name && Random(0.7f))
+        if (a.Name != result.Name && Random(0.15f)) // Wayfarer: 0.7f<0.15f
         {
             result.Seedless = true;
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Changes the extra seedless mutation roll that is done on hybridizing plants for seedlessness.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bandaid. But I'm going to be real, having 85% chance to fail transferring traits from a seedless plant to another non-seedless different species plant absolutely fucking **rots.** One day I'll get around to making that determinant mutation system.

Mathematical breakdown:
Before:
Assuming both plants crossing are not seedless, there is a 70% chance for the result to be seedless regardless.
Assuming one of the plants are seedless, you have a 50% chance on the first roll for the result to be seedless since the gene is being transferred, and an additional 70% chance on top of that, turning the probability of at least one success for turning the plant seedless into a whopping 85%.
Math (which I think is right, but I haven't done probability in a while so I could be wrong)
Roll 1 failure rate: (100% - 50% = 50% (or 0.50)
Roll 2 failure rate: (100% - 70% = 30% (or 0.30)
0.50 * 0.30 = 0.15 (or 15%)
Subtracted from total certainty = 100% - 15% = 85%

After:
Assuming both plants crossing are not seedless, there is a 15% chance for the result to be seedless regardless.
Assuming one of the plants are seedless, you have a 50% chance on the first roll for the result to be seedless since the gene is being transferred, and an additional 15% chance on top of that, turning the probability of at least one success for turning the plant seedless into 57.5%
Roll 1 failure rate: (100% - 50% = 50% (or 0.50)
Roll 2 failure rate: (100% - 15% = 85% (or 0.85)
0.50 * 0.85 = 0.425 (or 42.5%)
Subtracted from total certainty = 100% - 42.5% = 57.5%

## Technical details
Changed one float value.

## How to test
Swab different plants away, confirm probability.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Reduced the chance for hybrid crossing to turn plants seedless.
