### PR TITLE
Trait Tweaks V2

### DIFF
--- a/Content.Server/Bible/BibleSystem.cs
+++ b/Content.Server/Bible/BibleSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Actions;
 using Content.Shared.Bible;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reaction;
+using Content.Shared.CombatMode.Pacification; // Wayfarer
 using Content.Shared.Damage;
 using Content.Shared.Ghost.Roles.Components;
 using Content.Shared.IdentityManagement;
@@ -144,24 +145,33 @@ namespace Content.Server.Bible
                 return;
             }
 
-            // Wayfarer: A bible user's heal can no longer injure the target.
             // This only has a chance to fail if the target is not wearing anything on their head and is not a familiar.
-            //if (!_invSystem.TryGetSlotEntity(args.Target.Value, "head", out var _) && !HasComp<FamiliarComponent>(args.Target.Value))
-            //{
-            //    if (_random.Prob(component.FailChance))
-            //    {
-            //        var othersFailMessage = Loc.GetString(component.LocPrefix + "-heal-fail-others", ("user", Identity.Entity(args.User, EntityManager)), ("target", Identity.Entity(args.Target.Value, EntityManager)), ("bible", uid));
-            //        _popupSystem.PopupEntity(othersFailMessage, args.User, Filter.PvsExcept(args.User), true, PopupType.SmallCaution);
-            //
-            //        var selfFailMessage = Loc.GetString(component.LocPrefix + "-heal-fail-self", ("target", Identity.Entity(args.Target.Value, EntityManager)), ("bible", uid));
-            //        _popupSystem.PopupEntity(selfFailMessage, args.User, args.User, PopupType.MediumCaution);
-            //
-            //        _audio.PlayPvs(component.BibleHitSound, args.User);
-            //        _damageableSystem.TryChangeDamage(args.Target.Value, component.DamageOnFail, true, origin: uid);
-            //        _delay.TryResetDelay((uid, useDelay));
-            //        return;
-            //    }
-            //}
+            /* // Wayfarer: Not anymore.
+            if (!_invSystem.TryGetSlotEntity(args.Target.Value, "head", out var _) && !HasComp<FamiliarComponent>(args.Target.Value))
+            {
+                if (_random.Prob(component.FailChance))
+                {
+                    var othersFailMessage = Loc.GetString(component.LocPrefix + "-heal-fail-others", ("user", Identity.Entity(args.User, EntityManager)), ("target", Identity.Entity(args.Target.Value, EntityManager)), ("bible", uid));
+                    _popupSystem.PopupEntity(othersFailMessage, args.User, Filter.PvsExcept(args.User), true, PopupType.SmallCaution);
+
+                    var selfFailMessage = Loc.GetString(component.LocPrefix + "-heal-fail-self", ("target", Identity.Entity(args.Target.Value, EntityManager)), ("bible", uid));
+                    _popupSystem.PopupEntity(selfFailMessage, args.User, args.User, PopupType.MediumCaution);
+
+                    _audio.PlayPvs(component.BibleHitSound, args.User);
+                    _damageableSystem.TryChangeDamage(args.Target.Value, component.DamageOnFail, true, origin: uid);
+                    _delay.TryResetDelay((uid, useDelay));
+                    return;
+                }
+            }
+            */
+            // Checks to see if they are a pacifist. If not, no heal ability.
+            var hasPacifistComponent = HasComp<PacifiedComponent>(args.User);
+            if (!hasPacifistComponent)
+            {
+                _popupSystem.PopupEntity(Loc.GetString("bible-heal-fail-nonpacifist"), args.User, args.User);
+                _delay.TryResetDelay((uid, useDelay));
+                return;
+            }
             // End Wayfarer
 
             var damage = _damageableSystem.TryChangeDamage(args.Target.Value, component.Damage, true, origin: uid);

--- a/Content.Shared/Abilities/Mime/MimePowersComponent.cs
+++ b/Content.Shared/Abilities/Mime/MimePowersComponent.cs
@@ -52,7 +52,7 @@ public sealed partial class MimePowersComponent : Component
     /// How long it takes the mime to get their powers back
     /// </summary>
     [DataField, AutoNetworkedField]
-    public TimeSpan VowCooldown = TimeSpan.FromMinutes(5);
+    public TimeSpan VowCooldown = TimeSpan.FromMinutes(30); // Wayfarer: 5<30
 
     [DataField]
     public ProtoId<AlertPrototype> VowAlert = "VowOfSilence";

--- a/Resources/Locale/en-US/_NF/traits/traits.ftl
+++ b/Resources/Locale/en-US/_NF/traits/traits.ftl
@@ -13,7 +13,8 @@ trait-scandinavian-name = Scandinavian accent
 trait-scandinavian-desc = You have to assemble the sentence yourself.
 
 trait-pious-name = Pious
-trait-pious-desc = You are in touch with the gods, but your vows keep you from striking in anger.
+# Wayfarer: Changed Desc
+trait-pious-desc = You are more in touch with the gods than others.
 
 trait-streetpunk-accent-name = Streetpunk accent
 trait-streetpunk-accent-desc = Ya were born in a sprawlin' megacity an' never went to school. An' it shows, choom.

--- a/Resources/Locale/en-US/_WF/chapel/bible.ftl
+++ b/Resources/Locale/en-US/_WF/chapel/bible.ftl
@@ -1,0 +1,1 @@
+bible-heal-fail-nonpacifist = Only those who have taken a vow of pacifism can heal others with this.

--- a/Resources/Locale/en-US/alerts/alerts.ftl
+++ b/Resources/Locale/en-US/alerts/alerts.ftl
@@ -85,11 +85,11 @@ alerts-muted-name = Muted
 alerts-muted-desc = You have lost the ability to speak.
 
 alerts-vow-silence-name = Vow of Silence
-# Wayfarer
-alerts-vow-silence-desc = You have taken a vow forbidding verbal or written communication as part of initiation into the Mystiko Tagma Mimon.
+alerts-vow-silence-desc = You have taken a vow forbidding verbal or written communication as part of initiation into the Mystiko Tagma Mimon. Click to break your vow.
 
 alerts-vow-broken-name = Vow Broken
-alerts-vow-broken-desc = You've broken your vows to Mimes everywhere. You can speak and write, but you've lost your powers for at least 5 entire minutes!!! Click to try and retake your vow.
+# Wayfarer: Changed Desc
+alerts-vow-broken-desc = You've broken your vows to Mimes everywhere. You can speak and write, but you've lost your powers for at least 30 minutes. Click to try and retake your vow.
 
 alerts-pulled-name = Pulled
 alerts-pulled-desc = You're being pulled. Move to break free.

--- a/Resources/Prototypes/Alerts/alerts.yml
+++ b/Resources/Prototypes/Alerts/alerts.yml
@@ -388,7 +388,7 @@
   id: VowOfSilence
   icons: [ /Textures/Interface/Alerts/Abilities/silenced.png ]
   name: alerts-vow-silence-name
-#  clickEvent: !type:BreakVowAlertEvent # Wayfarer
+  clickEvent: !type:BreakVowAlertEvent
   description: alerts-vow-silence-desc
 
 - type: alert

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/implanters.yml
@@ -31,23 +31,21 @@
   - type: Implanter
     implant: GibAcidifierImplantNF
 
-# Wayfarer: Faith implanter and mime vow implanter removed. The mime vow is replaced by the new Mime trait. Faith is covered by the existing Pious trait.
-#- type: entity
-#  id: BibleUserImplanter
-#  name: faith implanter
-#  parent: BaseImplantOnlyImplanter
-#  components:
-#  - type: Implanter
-#    implant: BibleUserImplant
-#
-#- type: entity
-#  id: MimePowersImplanter
-#  name: mime vow implanter
-#  parent: BaseImplantOnlyImplanter
-#  components:
-#  - type: Implanter
-#    implant: MimePowersImplant
-# End Wayfarer
+- type: entity
+  id: BibleUserImplanter
+  name: faith implanter
+  parent: BaseImplantOnlyImplanter
+  components:
+  - type: Implanter
+    implant: BibleUserImplant
+
+- type: entity
+  id: MimePowersImplanter
+  name: mime vow implanter
+  parent: BaseImplantOnlyImplanter
+  components:
+  - type: Implanter
+    implant: MimePowersImplant
 
 # Centcomm implanters
 

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/subdermal_implants.yml
@@ -93,34 +93,32 @@
     - HideContextMenu
     - DeathAcidifier
 
-# Wayfarer: Faith implant and mime vow implant removed. The mime vow is replaced by the new Mime trait. Faith is covered by the existing Pious trait.
-#- type: entity
-#  parent: BaseSubdermalImplant
-#  id: BibleUserImplant
-#  name: faith implant
-#  description: This implant binds the user to the gods.
-#  categories: [ HideSpawnMenu ]
-#  components:
-#  - type: SubdermalImplant
-#    permanent: true
-#  - type: AddComponentsImplant
-#    componentsToAdd:
-#      - type: BibleUser
-#
-#- type: entity
-#  parent: BaseSubdermalImplant
-#  id: MimePowersImplant
-#  name: mime vow implant
-#  description: This implant lets the user take the mime's vow.
-#  categories: [ HideSpawnMenu ]
-#  components:
-#  - type: SubdermalImplant
-#    permanent: true
-#  - type: AddComponentsImplant
-#    componentsToAdd:
-#    - type: MimePowers
-#      preventWriting: false # Explicit in case upstream changes its mind on this.
-# End Wayfarer
+- type: entity
+  parent: BaseSubdermalImplant
+  id: BibleUserImplant
+  name: faith implant
+  description: This implant binds the user to the gods.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SubdermalImplant
+    permanent: true
+  - type: AddComponentsImplant
+    componentsToAdd:
+      - type: BibleUser
+
+- type: entity
+  parent: BaseSubdermalImplant
+  id: MimePowersImplant
+  name: mime vow implant
+  description: This implant lets the user take the mime's vow.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SubdermalImplant
+    permanent: true
+  - type: AddComponentsImplant
+    componentsToAdd:
+    - type: MimePowers
+      preventWriting: false # Explicit in case upstream changes its mind on this.
 
 - type: entity
   parent: BaseSubdermalImplant

--- a/Resources/Prototypes/_NF/Traits/quirks.yml
+++ b/Resources/Prototypes/_NF/Traits/quirks.yml
@@ -8,4 +8,4 @@
   traitGear: Bible
   components:
     - type: BibleUser
-    - type: Pacified
+  #  - type: Pacified # Wayfarer


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Reverts a few changes from https://github.com/project-wayfarer/wayfarer-14/pull/904
And makes a few brand new ones.

1: Mimes can break their vows again in case of emergency, but the penalty to retake their vows is increased to 30 minutes from 5.
2: Pious is separated from pacifism, but only pacifists can use the bible's heal ability.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Implanters were removed from drop tables and loadouts, but unnecessarily had their items and base implant definitions removed, which prevented admins from fucking around with these. Originally, this was what this PR would be about, but I decided to tackle another issue.
People wanted to be able to have the pious trait without the pacifism it incurs, and mainly the concern with that was that it gave them access to a free heal. This changes that, only allowing people that have BOTH the pacifist trait and pious to perform the heal ability.
Thus, the concern of mercs healing themselves with these in combat has been entirely squashed.

## Technical details
Mostly yml, with one extra check in C# for the pacified component, which the pacifist trait gives.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Spawn as a pious character, try to heal a damaged urist.
Spawn as a pious and pacifist character, try to heal a damaged urist.

Break your vow as a mime, verify the action button to retake the vow.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="430" height="102" alt="image" src="https://github.com/user-attachments/assets/32373c46-5b95-4e28-9031-7b00470ad658" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Pacifism is no longer tied to Pious.
- tweak: Only Pious characters with the Pacifism trait can use religious books' innate ability to heal others.