### PR TITLE
Replace mention of Nanotrasen for UIV Event

### DIFF
--- a/Resources/Locale/en-US/_NF/bluespace-events/events.ftl
+++ b/Resources/Locale/en-US/_NF/bluespace-events/events.ftl
@@ -35,7 +35,7 @@ station-event-bluespace-bloodmoon-start-announcement = Attention all available W
 station-event-bluespace-bloodmoon-warning-announcement = Remote FTL procedures initialized, five minutes until Blood Cult vessel dissipation.
 station-event-bluespace-bloodmoon-end-announcement = In compliance with Concordia Governments FTL traffic patterns, the unknown ship has been dissipated to ensure non-collision.
 
-station-event-bluespace-generic-ftl-start-announcement = Attention all Wayfarers! Concordia's Naval Command has detected an unidentified vessel entering the Zekke Sector. Investigate with caution, NanoTrasen is not liable for damages sustained or loss of life.
+station-event-bluespace-generic-ftl-start-announcement = Attention all Wayfarers! Concordia's Naval Command has detected an unidentified vessel entering the Zekke Sector. Investigate with caution, Concordia is not liable for damages sustained or loss of life.
 station-event-bluespace-generic-ftl-warning-announcement = Remote FTL procedures initialized, five minutes until unidentified vessel dissipation.
 station-event-bluespace-generic-ftl-end-announcement = In compliance with Concordia Governments FTL traffic patterns, the unknown ship has been dissipated to ensure non-collision.
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This is a one line change to an event that still mentions Nanotrasen

## Why / Balance
It annoyed me - and I wanted a very simple commit to learn how to contribute to SS14 ahead of diving into more complex stuff.

## Technical details
One word changed in bluespace-events/events.ftl.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
- Trigger a UIV event (or wait)
- Confirm that you are not in the same dimension as that evil megacorp
- get distracted thinking about why coffee is still called Nanocaf.
- test complete.

## Media
Exempt, as its a small change. 


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
Not gameplay affecting, so I don't think one is needed?
