### PR TITLE
Add GravityAffected to BaseVehicle (#4194)

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Vehicles/vehicles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Vehicles/vehicles.yml
@@ -24,6 +24,7 @@
   - type: Access
   - type: Physics
     bodyType: KinematicController # Frontier: Dynamic<KinematicController - it moves, it's kinematic
+  - type: GravityAffected # Frontier: prevent space movement unless MovementIgnoreGravity is also present
   - type: Fixtures
     fixtures:
       fix1:
@@ -286,6 +287,7 @@
     friction: 2.5 # Frontier: 0.5<2.5
     baseSprintSpeed: 3.5
     baseWalkSpeed: 2.5
+  - type: MovementIgnoreGravity # Frontier: float through space
   - type: StaticPrice
     price: 175
   #- type: PhysicalComposition # Frontier


### PR DESCRIPTION
Ports: https://github.com/new-frontiers-14/frontier-station-14/pull/4194
Copied PR, no changes.

## About the PR
Adds `GravityAffectedComponent` to `BaseVehicle`, to prevent driving through space (off-grid) when it doesn't make sense.

## Why / Balance
Wheeled vehicles – ATVs, segways, the skeleton motorcycle, possibly more – can currently drive through space. This is obviously unintended. Only hoverbikes, hoverchairs and the cool new broom are meant to be space-usable. By adding `GravityAffected`, we ensure these vehicles are not drivable off-grid, i.e. in space. Vehicles that are already intended to be usable without gravity already have `MovementIgnoreGravity`.

This bug likely occurred a consequence of upstream reworking gravity.

## Technical details
Yam nam naML

## How to test
1. Spawn a variety of vehicles: ATV, skeleton motorcycle (essential), segway, broom, hoverbike, hoverchair, wheelchair, goblin dumpster, whatever else you can find.
2. Ensure every vehicle is drivable in gravity.
3. Disable gravity.
4. Ensure all vehicles are still drivable *on grid*, even in zero-gravity.
5. Remove the tiles beneath your vehicles.
6. Ensure only hoverbikes, brooms and hoverchairs remain drivable in space. All other vehicles should remain motionless when you try to move them.

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes

**Changelog**
:cl:
- fix: Wheeled vehicles can no longer be driven in space. Grab a hoverbike or equivalent if you wanna do that!