### PR TITLE
Fix Error Sprite for Facehugger Plushie (#4585)

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Masks/masks.yml
@@ -13,7 +13,7 @@
     - Hair
 
 - type: entity
-  parent: [PlushieXeno, ClothingMaskBase]
+  parent: [ClothingMaskBase, PlushieXeno]
   id: FaceHuggerPlushie
   name: facehugger plushie
   description: The perfect plushie to scare your friends with aliens!


### PR DESCRIPTION
Ports: https://github.com/new-frontiers-14/frontier-station-14/pull/4585
Closes https://github.com/project-wayfarer/wayfarer-14/issues/1217

## About the PR
Changed parent order on Facehugger Plushie to properly display and function as a mask

## Why / Balance
When worn it should not display the error texture.

## Technical details
Original parent order had it function as a hat instead of a mask, thus looking for an equipped-HELMET sprite that doesn't exist. Having the PlushieXeno parent apply before the ClothingMaskBase makes it properly equip as a mask. 

## How to test
1. Get a facehugger plushie
2. Let it hug your face
3. Mmmf mrrfff!
4. Scream for the corpsman

## Media
<img width="548" height="704" alt="image" src="https://github.com/user-attachments/assets/6af28293-e2d1-4b39-a5bb-a1dbe800bb5d" />


## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes

**Changelog**
:cl:
- fix: Fixed ERROR facehugger sprite. 