### PR TITLE
Prevents Anomaly Infections From Gibbing Players on Supercrit

### DIFF
--- a/Content.Server/Anomaly/Effects/InnerBodyAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/InnerBodyAnomalySystem.cs
@@ -134,7 +134,7 @@ public sealed class InnerBodyAnomalySystem : SharedInnerBodyAnomalySystem
         if (!TryComp<BodyComponent>(ent, out var body))
             return;
 
-        _body.GibBody(ent, true, body, splatModifier: 5f);
+        //_body.GibBody(ent, true, body, splatModifier: 5f); // Wayfarer
     }
 
     private void OnSeverityChanged(Entity<InnerBodyAnomalyComponent> ent, ref AnomalySeverityChangedEvent args)

--- a/Content.Server/Anomaly/Effects/InnerBodyAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/InnerBodyAnomalySystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Anomaly.Components;
 using Content.Shared.Anomaly.Effects;
 using Content.Shared.Body.Components;
 using Content.Shared.Chat;
+using Content.Shared.Damage; // Wayfarer
 using Content.Shared.Database;
 using Content.Shared.Mobs;
 using Content.Shared.Popups;
@@ -34,6 +35,7 @@ public sealed class InnerBodyAnomalySystem : SharedInnerBodyAnomalySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly StunSystem _stun = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!; // Wayfarer;
 
     private readonly Color _messageColor = Color.FromSrgb(new Color(201, 22, 94));
 
@@ -134,7 +136,8 @@ public sealed class InnerBodyAnomalySystem : SharedInnerBodyAnomalySystem
         if (!TryComp<BodyComponent>(ent, out var body))
             return;
 
-        //_body.GibBody(ent, true, body, splatModifier: 5f); // Wayfarer
+        _damageable.TryChangeDamage(ent, ent.Comp.DamageOnSuperCrit, true); // Wayfarer
+        //_body.GibBody(ent, true, body, splatModifier: 5f); // Wayfarer: Commented out
     }
 
     private void OnSeverityChanged(Entity<InnerBodyAnomalyComponent> ent, ref AnomalySeverityChangedEvent args)

--- a/Content.Shared/Anomaly/Components/InnerBodyAnomalyComponent.cs
+++ b/Content.Shared/Anomaly/Components/InnerBodyAnomalyComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared.Anomaly.Effects;
 using Content.Shared.Body.Prototypes;
+using Content.Shared.Damage; // Wayfarer
 using Content.Shared.Humanoid.Prototypes;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
@@ -70,6 +71,17 @@ public sealed partial class InnerBodyAnomalyComponent : Component
     /// </summary>
     [DataField]
     public string LayerMap = "inner_anomaly_layer";
+
+    // Wayfarer: Damage on anomaly infection supercrit
+    [DataField]
+    public DamageSpecifier DamageOnSuperCrit = new()
+    {
+        DamageDict = new ()
+        {
+            { "Heat", 500 },
+        }
+    };
+    // End Wayfarer
 }
 
 /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Title.
Makes it so it deals damage instead.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Probably not something we want, but up for debate.

## Technical details
The anomaly now calls upon a damage specifier to deal damage to the player that was infected.

## Media

<img width="283" height="263" alt="image" src="https://github.com/user-attachments/assets/62f0a0f7-5b64-46fd-ada8-9abc89548d31" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Anomaly infections can no longer gib players, instead dealing damage.