### PR TITLE
Massive SR QoL: Airlock Docking Time Timestamp Component

### DIFF
--- a/Content.Server/_WF/Shuttles/Systems/DockTimestampSystem.cs
+++ b/Content.Server/_WF/Shuttles/Systems/DockTimestampSystem.cs
@@ -1,0 +1,66 @@
+using Content.Server.Shuttles.Components;
+using Content.Server.Shuttles.Events;
+using Content.Shared.Examine;
+using Content.Shared._WF.Shuttles.Components;
+using Content.Shared.Shuttles.Components;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+
+namespace Content.Server._WF.Shuttles.Systems;
+
+public sealed class DockTimestampSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DockingComponent, DockEvent>(OnDock);
+        SubscribeLocalEvent<DockingComponent, UndockEvent>(OnUndock);
+
+        SubscribeLocalEvent<DockTimestampComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnDock(Entity<DockingComponent> ent, ref DockEvent args)
+    {
+        // Make sure we only track airlock type airlocks... Could be problematic if not.
+        if (!ent.Comp.DockType.HasFlag(DockType.Airlock))
+            return;
+
+        // Add the timestamp component if it doesn't exist yet (first dock)
+        var timestamp = EnsureComp<DockTimestampComponent>(ent);
+        timestamp.DockStartTime = _timing.CurTime;
+        Dirty(ent, timestamp); // Why do I always feel dirty using Dirty()?
+    }
+
+    private void OnUndock(Entity<DockingComponent> ent, ref UndockEvent args)
+    {
+        if (!TryComp<DockTimestampComponent>(ent, out var timestamp))
+            return;
+
+        timestamp.DockStartTime = null;
+        Dirty(ent, timestamp);
+    }
+
+    private void OnExamined(Entity<DockTimestampComponent> ent, ref ExaminedEvent args)
+    {
+        if (ent.Comp.DockStartTime is not { } startTime)
+            return;
+
+        var elapsed = _timing.CurTime - startTime;
+        var timeString = FormatDuration(elapsed);
+
+        var msg = new FormattedMessage();
+        args.PushMarkup(Loc.GetString("dock-timestamp-examine", ("time", timeString)), -111);
+    }
+
+    private static string FormatDuration(TimeSpan duration)
+    {
+        if (duration.TotalDays >= 1)
+            return $"{(int)duration.TotalDays}d {duration.Hours:D2}:{duration.Minutes:D2}:{duration.Seconds:D2}";
+        if (duration.TotalHours >= 1)
+            return $"{(int)duration.TotalHours}:{duration.Minutes:D2}:{duration.Seconds:D2}";
+        return $"{duration.Minutes:D2}:{duration.Seconds:D2}";
+    }
+}

--- a/Content.Shared/_WF/Shuttles/Components/DockTimestampComponent.cs
+++ b/Content.Shared/_WF/Shuttles/Components/DockTimestampComponent.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._WF.Shuttles.Components;
+
+/// <summary>
+/// Stores the time a docking port became docked. SR QOL for people being naughty with the docks.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class DockTimestampComponent : Component
+{
+    /// <summary>
+    /// The game time when docking started, or null if not docked.
+    /// </summary>
+    [AutoNetworkedField]
+    public TimeSpan? DockStartTime;
+}

--- a/Resources/Locale/en-US/_WF/shuttles/dock-timestamp.ftl
+++ b/Resources/Locale/en-US/_WF/shuttles/dock-timestamp.ftl
@@ -1,0 +1,1 @@
+dock-timestamp-examine = [color=yellow]Docked for [/color][color=red]{$time}[/color]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Lets people see for how long a shuttle has been docked to an airlock.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
SRs need this to enforce improper parking penalties, unironically.

## Technical details
<!-- Summary of code changes for easier review. -->
A stupid component and an even stupider system.
Completely and fully modular, doesn't require any base namespace changes, works by subscribing to dock and undock events and attaching its own component. Someone could probably hook into this in the shuttle console UI to make that easier even easier for SRs to view.

For reasons unknown to me, I couldn't put this on a simple client system without the examine message magically disappearing.

## How to test
Buy ship. Examine dock. Undock. Examine dock. Dock again, examine dock.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="728" height="515" alt="image" src="https://github.com/user-attachments/assets/eed29906-bb96-4dc7-8363-d921773e50de" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Docks can be examined to see for how long something has been docked there.
