### PR TITLE
Wayfarer PDA loadout Additions and Adjustments

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -1166,7 +1166,7 @@
   parent: [ BasePDA ] # Wayfarer: Removed Contraband
   id: SyndiPDA
   name: red PDA # Wayfarer: Renamed
-  description: 99 and 44/100ths percent pure plastic. # Ok, time to be a productive member of- oh cool I'm a bad guy time to kill people! # Wayfarer
+  description: Be honest... you probably stole this. # Ok, time to be a productive member of- oh cool I'm a bad guy time to kill people! # Wayfarer
   components:
   - type: Pda
     id: SyndicateIDCard
@@ -1562,7 +1562,7 @@
   parent: [ BaseMedicalPDA ] # Wayfarer: Removed Contraband
   id: SyndiAgentPDA
   name: red corpsman PDA # Wayfarer: Renamed
-  description: Frozen from so many deep space rescues. #For those days when healing normal syndicates aren't enough, try healing nuclear operatives instead! # Wayfarer
+  description: Even Coldlight needs medics. #For those days when healing normal syndicates aren't enough, try healing nuclear operatives instead! # Wayfarer
   components:
   - type: Pda
     id: SyndicateIDCard

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/pda.yml
@@ -412,7 +412,7 @@
   suffix: Frontier
   components:
   - type: Pda
-    id: NFPirateIDCard
+    id: ContractorIDCard # Wayfarer NFPirateIDCard<ContractorIDCard
   - type: Appearance
     appearanceDataInit:
       enum.PdaVisuals.PdaType:
@@ -432,7 +432,7 @@
   suffix: Frontier
   components:
   - type: Pda
-    id: NFPirateCaptainIDCard
+    id: ContractorIDCard # Wayfarer NFPirateCaptainIDCard<ContractorIDCard
   - type: Appearance
     appearanceDataInit:
       enum.PdaVisuals.PdaType:

--- a/Resources/Prototypes/_WF/Loadouts/Jobs/Wayfarer/pda.yml
+++ b/Resources/Prototypes/_WF/Loadouts/Jobs/Wayfarer/pda.yml
@@ -390,7 +390,7 @@
   effects:
   - !type:GroupLoadoutEffect
     proto: WFT3
-  price: 20000
+  price: 10000
   equipment:
     id: SyndiAgentPDA
 
@@ -399,6 +399,24 @@
   effects:
   - !type:GroupLoadoutEffect
     proto: WFT3
-  price: 20000
+  price: 10000
   equipment:
     id: SyndiPDA
+
+- type: loadout
+  id: WFPiratePDA
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: WFT3
+  price: 1000
+  equipment:
+    id: NFPiratePDA
+
+- type: loadout
+  id: WFCrackedPDA
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: WFT3
+  price: 1000
+  equipment:
+    id: NFPirateCaptainPDA

--- a/Resources/Prototypes/_WF/Loadouts/wayfarer_loadout_groups.yml
+++ b/Resources/Prototypes/_WF/Loadouts/wayfarer_loadout_groups.yml
@@ -1501,6 +1501,8 @@
   - WFJesterPDA
   - WFSyndiAgentPDA
   - WFSyndiPDA
+  - WFPiratePDA
+  - WFCrackedPDA
 
 
   fallbacks:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds the Cracked PDA and Pirate PDA to loadouts for wayfarers.
The IDs do **not** provide access and both the IDs and the PDAs are unobtanium outside of chameleon otherwise which is lame.
Adjust the Coldlight/Red/Syndicate PDAs price (frankly even halved this price is absurd) and provides custom descriptions to both as they were not provided that deserved effort when adjusted originally. 

Combined with my UI changes a while back these are pretty neat now. Maybe people will use them.

Additional changes made with #1251 in mind, providing base ID for both PDAs.

## Why / Balance
Yes

## Technical details
Yaml

## How to test
Wayfarer loadout _heeeeebrbrbrr_

## Media
<img width="762" height="427" alt="image" src="https://github.com/user-attachments/assets/72c1488c-513e-4339-9ea4-c9f76ef96ec4" />
<img width="721" height="497" alt="image" src="https://github.com/user-attachments/assets/2cf0210e-18e1-48fe-8a3d-87e141ae4c13" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Added Cracked and Pirate PDAs to loadouts.
- tweak: Changed Red PDA vales slightly and updated descriptions.
