### PR TITLE
Portable Recharger can now be worn on your belt and suit storage slot…

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/portable_recharger.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/portable_recharger.yml
@@ -14,8 +14,17 @@
     quickEquip: false
     slots:
     - back
+    - Belt # Frontier
+    - suitStorage #Frontier
+    clothingVisuals: #Frontier
+      back:
+      - state: charging-equipped-BACKPACK
+      belt:
+      - state: charging-equipped-BACKPACK
+      suitstorage:
+      - state: charging-equipped-BACKPACK
   - type: Charger
-    chargeRate: 50 # Frontier: chargeRate: 50 
+    chargeRate: 50 # Frontier: chargeRate: 50
     slotId: charger_slot
     portable: true
   - type: PowerChargerVisuals
@@ -32,7 +41,7 @@
   - type: ItemSlots
     slots:
       charger_slot:
-        ejectOnInteract: true
+        # ejectOnInteract: true # Frontier: In a fit of irony, this prevents you drawing the item in the slot by interacting.
         whitelist:
           components:
           - HitscanBatteryAmmoProvider


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Ports Frontier PR [#4527](https://github.com/new-frontiers-14/frontier-station-14/pull/4527)
Portable Recharger can now be worn on your belt and suit storage slots

Can now alt click to eject items

## Why / Balance
Portable charger is barely portable. Giving up your backpack slot for something that makes lasers way more viable sucks.

## Technical details
Cherrypick from Frontier PR

## How to test
Spawn portable charger
Put on back
Put on belt
Put an energy weapon/tool inside, alt click to take it out

## Media
<img width="484" height="690" alt="image" src="https://github.com/user-attachments/assets/3297b2c3-1ad3-4b99-98e8-0694a3b8e314" />

<img width="504" height="667" alt="image" src="https://github.com/user-attachments/assets/f061d6a6-a761-4421-9554-250620f2d9b7" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Portable rechargers may now be worn on the back and belt slots.

