### PR TITLE
Job Reopening on Extended SSD

### DIFF
--- a/Content.Server/_NF/Roles/Systems/JobTrackingSystem.cs
+++ b/Content.Server/_NF/Roles/Systems/JobTrackingSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared._NF.Roles.Components;
 using Content.Shared._NF.Roles.Systems;
 using Content.Shared.Mind.Components;
 using Content.Shared.Roles;
+using Content.Shared.SSDIndicator; // Wayfarer
 using Robust.Server.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
@@ -32,6 +33,7 @@ public sealed class JobTrackingSystem : SharedJobTrackingSystem
         SubscribeLocalEvent<JobTrackingComponent, CryosleepBeforeMindRemovedEvent>(OnJobBeforeCryoEntered);
         SubscribeLocalEvent<JobTrackingComponent, MindAddedMessage>(OnJobMindAdded);
         SubscribeLocalEvent<JobTrackingComponent, MindRemovedMessage>(OnJobMindRemoved);
+        SubscribeLocalEvent<JobTrackingComponent, SSDJobReopenEvent>(OnJobSSDReopen); // Wayfarer
     }
 
     // If, through admin jiggery pokery, the player returns (or the mob is controlled), we should close the slot if it's opened.
@@ -147,4 +149,15 @@ public sealed class JobTrackingSystem : SharedJobTrackingSystem
         }
         return activeJobCount;
     }
+    // Wayfarer Start
+    private void OnJobSSDReopen(Entity<JobTrackingComponent> ent, ref SSDJobReopenEvent ev)
+    {
+        if (ent.Comp.Job == null
+            || !ent.Comp.Active
+            || !JobShouldBeReopened(ent.Comp.Job.Value))
+            return;
+
+        OpenJob(ent);
+    }
+    // End Wayfarer
 }

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._WF.CCVar; // Wayfarer
 using Content.Shared.CCVar;
 using Content.Shared.StatusEffectNew;
 using Robust.Shared.Configuration;
@@ -10,7 +11,7 @@ namespace Content.Shared.SSDIndicator;
 /// <summary>
 ///     Handle changing player SSD indicator status
 /// </summary>
-public sealed class SSDIndicatorSystem : EntitySystem
+public sealed partial class SSDIndicatorSystem : EntitySystem // Wayfarer: Add Partial
 {
     public static readonly EntProtoId StatusEffectSSDSleeping = "StatusEffectSSDSleeping";
 
@@ -29,11 +30,13 @@ public sealed class SSDIndicatorSystem : EntitySystem
 
         _cfg.OnValueChanged(CCVars.ICSSDSleep, obj => _icSsdSleep = obj, true);
         _cfg.OnValueChanged(CCVars.ICSSDSleepTime, obj => _icSsdSleepTime = obj, true);
+        _cfg.OnValueChanged(WFCCVars.SSDJobReopenMinutes, obj => _jobReopenMinutes = obj, true); // Wayfarer
     }
 
     private void OnPlayerAttached(EntityUid uid, SSDIndicatorComponent component, PlayerAttachedEvent args)
     {
         component.IsSSD = false;
+        component.WentSSDAt = TimeSpan.Zero; // Wayfarer
 
         // Removes force sleep and resets the time to zero
         if (_icSsdSleep)
@@ -48,6 +51,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
     private void OnPlayerDetached(EntityUid uid, SSDIndicatorComponent component, PlayerDetachedEvent args)
     {
         component.IsSSD = true;
+        component.WentSSDAt = _timing.CurTime; // Wayfarer
 
         // Sets the time when the entity should fall asleep
         if (_icSsdSleep)
@@ -72,6 +76,8 @@ public sealed class SSDIndicatorSystem : EntitySystem
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
+
+        PeriodicSSDCheckForJobReopening(); // Wayfarer hook to check if we can open a job.
 
         if (!_icSsdSleep)
             return;

--- a/Content.Shared/_WF/CCVar/WFCCVars.cs
+++ b/Content.Shared/_WF/CCVar/WFCCVars.cs
@@ -34,4 +34,10 @@ public sealed class WFCCVars
     /// </summary>
     public static readonly CVarDef<bool> CorporationStationPurchaseEnabled =
         CVarDef.Create("wf.corporation.station_purchase_enabled", false, CVar.SERVER);
+
+    /// <summary>
+    /// If a character is SSD, wait this many minutes before reopening their job.
+    /// </summary>
+    public static readonly CVarDef<float> SSDJobReopenMinutes =
+        CVarDef.Create("wf.ssd_job_reopen_minutes", 120f, CVar.SERVER);
 }

--- a/Content.Shared/_WF/SSDIndicator/SSDIndicatorComponent.cs
+++ b/Content.Shared/_WF/SSDIndicator/SSDIndicatorComponent.cs
@@ -1,0 +1,26 @@
+using Content.Shared.CCVar;
+using Content.Shared.StatusIcon;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared.SSDIndicator;
+
+/// <summary>
+/// Shows status icon when an entity is SSD, based on if a player is attached or not.
+/// </summary>
+public sealed partial class SSDIndicatorComponent
+{
+    /// <summary>
+    /// They went SSD at this time.
+    /// </summary>
+    [DataField]
+    [AutoNetworkedField]
+    public TimeSpan WentSSDAt = TimeSpan.Zero;
+
+    /// <summary>
+    /// The job that was opened when they went SSD.
+    /// Prevents reopening the job if they go SSD again within a certain time frame.
+    /// </summary>
+    public bool JobOpened = false;
+}

--- a/Content.Shared/_WF/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/_WF/SSDIndicator/SSDIndicatorSystem.cs
@@ -1,0 +1,47 @@
+using Content.Shared._WF.CCVar;
+using Content.Shared.CCVar;
+using Content.Shared.StatusEffectNew;
+using Robust.Shared.Configuration;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+using Robust.Shared.Network;
+
+namespace Content.Shared.SSDIndicator;
+
+public sealed partial class SSDIndicatorSystem : EntitySystem
+{
+    private float _jobReopenMinutes = 60f;
+    private TimeSpan _nextJobReopenCheck = TimeSpan.Zero;
+    private static readonly TimeSpan JobReopenCheckInterval = TimeSpan.FromSeconds(45);
+    [Dependency] private readonly INetManager _net = default!; // Wayfarer
+
+    private void HandleReopenJob(EntityUid uid, SSDIndicatorComponent comp)
+    {
+        if (!comp.IsSSD
+            || comp.WentSSDAt == TimeSpan.Zero
+            || comp.JobOpened)
+            return;
+
+        var curTime = _timing.CurTime;
+        if (curTime < comp.WentSSDAt + TimeSpan.FromMinutes(_jobReopenMinutes))
+            return;
+
+        var ev = new SSDJobReopenEvent(uid);
+        RaiseLocalEvent(uid, ev);
+        comp.JobOpened = true;
+    }
+    private void PeriodicSSDCheckForJobReopening()
+    {
+        if (_net.IsServer && _timing.CurTime >= _nextJobReopenCheck)
+        {
+            _nextJobReopenCheck = _timing.CurTime + JobReopenCheckInterval;
+
+            var query = EntityQueryEnumerator<SSDIndicatorComponent>();
+            while (query.MoveNext(out var uid, out var comp))
+            {
+                HandleReopenJob(uid, comp);
+            }
+        }
+    }
+}

--- a/Content.Shared/_WF/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/_WF/SSDIndicator/SSDIndicatorSystem.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.SSDIndicator;
 
 public sealed partial class SSDIndicatorSystem : EntitySystem
 {
-    private float _jobReopenMinutes = 60f;
+    private float _jobReopenMinutes = 120f;
     private TimeSpan _nextJobReopenCheck = TimeSpan.Zero;
     private static readonly TimeSpan JobReopenCheckInterval = TimeSpan.FromSeconds(45);
     [Dependency] private readonly INetManager _net = default!; // Wayfarer

--- a/Content.Shared/_WF/SSDIndicator/SSDJobReopenEvent.cs
+++ b/Content.Shared/_WF/SSDIndicator/SSDJobReopenEvent.cs
@@ -1,0 +1,13 @@
+namespace Content.Shared.SSDIndicator;
+/// <summary>
+/// Just tells the job system to try to reopen the job.
+/// </summary>
+public sealed class SSDJobReopenEvent : EntityEventArgs
+{
+    public EntityUid User { get; set; }
+
+    public SSDJobReopenEvent(EntityUid user)
+    {
+        User = user;
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Partial, modified port of https://github.com/ARF-SS13/coyote-frontier/pull/181

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
We needed a system to reopen jobs when certain roles have been exhausted and the people therein are SSD for a long period of time.

## Technical details
<!-- Summary of code changes for easier review. -->
Basically, every 45 seconds it will check every person with the ssdindicator and evaluate if they have been SSD for over two hours. If so, the job slot they had in use will be reopened.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Open the dev environment in release mode. Reduce the cvar to 2 minutes. Join as an SR or other limited role, disconnect. Join your localhost through the launcher to be recognized as another client. Wait. Observe. Respawn. See that the job slot for SR should be open again.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Jobs are now reopened if they are limited jobs and the person in that job has been away for longer than two hours.
