### PR TITLE
Crew Manifest Fix for Certain ID Cards

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/Misc/identification_cards.yml
@@ -225,7 +225,7 @@
   suffix: Frontier
   components:
   - type: PresetIdCard
-    job: NFPirate
+    job: Wayfarer # Wayfarer: NFPirate < Wayfarer
   - type: Sprite
     sprite: _NF/Objects/Misc/id_cards.rsi
     layers:
@@ -241,7 +241,7 @@
   description: Ahoy, see how it glistens!
   components:
   - type: PresetIdCard
-    job: NFPirateCaptain
+    job: Wayfarer # Wayfarer: NFPirateCaptain < Wayfarer
   - type: Sprite
     sprite: _NF/Objects/Misc/id_cards.rsi
     layers:
@@ -254,7 +254,7 @@
   name: pirate first mate ID card
   components:
   - type: PresetIdCard
-    job: NFPirateFirstMate
+    job: # Wayfarer: NFPirateFirstMate < Wayfarer
   - type: Sprite
     sprite: _NF/Objects/Misc/id_cards.rsi
     layers:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Due to the additions made and reverted with the changeable ID this was a leftover issue.
So right now, without this, anyone using cracked or pirate pda will be listed as an outlaw.

## Why / Balance
Crew manifest needs to be fixed as a whole but this prevents misinformation.

## Technical details
Yaml

## How to test
Have cracked or pirate PDA spawn in.

## Media
<img width="746" height="682" alt="image" src="https://github.com/user-attachments/assets/e76f4f64-3ea5-4d79-b399-789f798c6358" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- fix: Fixed dumb crew manifest issue with certain IDs.
