### PR TITLE
fix(shadekin): add missing localization

### DIFF
--- a/Resources/Locale/en-US/_Starlight/chat/emotes.ftl
+++ b/Resources/Locale/en-US/_Starlight/chat/emotes.ftl
@@ -2,6 +2,7 @@
 chat-emote-name-hiss = Hiss
 chat-emote-name-trill = Trill
 chat-emote-name-marr = Marr
+chat-emote-name-wurble = Wurble
 chat-emote-name-scree = Scree
 chat-emote-name-call = Call
 chat-emote-name-squawk = Squawk
@@ -10,6 +11,7 @@ chat-emote-name-squawk = Squawk
 chat-emote-msg-hiss = hisses
 chat-emote-msg-trill = trills
 chat-emote-msg-marr = marrs
+chat-emote-msg-wurble = wurbles
 chat-emote-msg-scree = screes
 chat-emote-msg-call = calls
 chat-emote-msg-squawk = squawks


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Add missing localization for shadekin's wurbles emote

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->