### PR TITLE
Bump oft used fluid containers to divisible units.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -99,7 +99,7 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 50
+        maxVol: 60 # Wayfarer: 50<60
   - type: Sprite
     sprite: Objects/Consumable/Drinks/beer.rsi
   - type: DamageOnLand
@@ -723,7 +723,7 @@
       drink:
         reagents:
         - ReagentId: Water
-          Quantity: 30
+          Quantity: 60 # Wayfarer: 30<60
   - type: Sprite
     sprite: Objects/Consumable/Drinks/waterbottle.rsi
   - type: Label

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -17,7 +17,7 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 20
+        maxVol: 25 # Wayfarer: 20<25
   - type: MixableSolution
     solution: drink
   - type: FitsInDispenser

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_flasks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_flasks.yml
@@ -6,7 +6,7 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 30
+        maxVol: 60 # Wayfarer: 30<60
   - type: Sprite
     state: icon
     sprite: Objects/Consumable/Drinks/flask.rsi

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_special.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_special.yml
@@ -7,7 +7,7 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 100
+        maxVol: 120 # Wayfarer: 100<120
   - type: MixableSolution
     solution: drink
   - type: Drink

--- a/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
@@ -15,10 +15,10 @@
   - type: SolutionContainerManager
     solutions:
       spray:
-        maxVol: 100
+        maxVol: 120 # Wayfarer: 100<120
         reagents:
         - ReagentId: Water
-          Quantity: 100
+          Quantity: 120 # Wayfarer: 100<120
   - type: RefillableSolution
     solution: spray
   - type: DrainableSolution

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -23,7 +23,7 @@
   - type: SolutionContainerManager
     solutions:
       spray:
-        maxVol: 100
+        maxVol: 120 # Wayfarer: 100<120
   - type: RefillableSolution
     solution: spray
   - type: DrainableSolution
@@ -57,7 +57,7 @@
   - type: SolutionContainerManager
     solutions:
       spray:
-        maxVol: 250
+        maxVol: 300 # Wayfarer: 250<300
   - type: Spray
     transferAmount: 15
     sprayedPrototype: BigVapor
@@ -78,10 +78,10 @@
   - type: SolutionContainerManager
     solutions:
       spray:
-        maxVol: 100
+        maxVol: 120 # Wayfarer: 100<120
         reagents:
         - ReagentId: Water
-          Quantity: 100
+          Quantity: 120 # Wayfarer: 100<120
 
 - type: entity
   name: space cleaner
@@ -93,10 +93,10 @@
   - type: SolutionContainerManager
     solutions:
       spray:
-        maxVol: 100
+        maxVol: 120 # Wayfarer: 100<120
         reagents:
         - ReagentId: SpaceCleaner
-          Quantity: 100
+          Quantity: 120 # Wayfarer: 100<120
   - type: Tag
     tags:
       - Spray

--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -7,7 +7,7 @@
     - type: SolutionContainerManager
       solutions:
         beaker:
-          maxVol: 200
+          maxVol: 240 # Wayfarer: 200<240
     - type: Sprite
       sprite: _DV/Objects/Specific/Chemistry/jug.rsi # DeltaV - Resprited some medical items
       layers:
@@ -100,7 +100,7 @@
       beaker:
         reagents:
         - ReagentId: Carbon
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -115,7 +115,7 @@
       beaker:
         reagents:
         - ReagentId: Iodine
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -130,7 +130,7 @@
       beaker:
         reagents:
         - ReagentId: Fluorine
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -145,7 +145,7 @@
       beaker:
         reagents:
         - ReagentId: Chlorine
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -160,7 +160,7 @@
       beaker:
         reagents:
         - ReagentId: Aluminium
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -175,7 +175,7 @@
       beaker:
         reagents:
         - ReagentId: Phosphorus
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -190,7 +190,7 @@
       beaker:
         reagents:
         - ReagentId: Sulfur
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -205,7 +205,7 @@
       beaker:
         reagents:
         - ReagentId: Silicon
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -220,7 +220,7 @@
       beaker:
         reagents:
         - ReagentId: Hydrogen
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -235,7 +235,7 @@
       beaker:
         reagents:
         - ReagentId: Lithium
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -250,7 +250,7 @@
       beaker:
         reagents:
         - ReagentId: Sodium
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -265,7 +265,7 @@
       beaker:
         reagents:
         - ReagentId: Potassium
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -280,7 +280,7 @@
       beaker:
         reagents:
         - ReagentId: Radium
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -295,7 +295,7 @@
       beaker:
         reagents:
         - ReagentId: Iron
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -310,7 +310,7 @@
       beaker:
         reagents:
         - ReagentId: Copper
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -325,7 +325,7 @@
       beaker:
         reagents:
         - ReagentId: Gold
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -340,7 +340,7 @@
       beaker:
         reagents:
         - ReagentId: Mercury
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -355,7 +355,7 @@
       beaker:
         reagents:
         - ReagentId: Silver
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -370,7 +370,7 @@
       beaker:
         reagents:
         - ReagentId: Ethanol
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -385,7 +385,7 @@
       beaker:
         reagents:
         - ReagentId: Sugar
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -400,7 +400,7 @@
       beaker:
         reagents:
         - ReagentId: Nitrogen
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -415,7 +415,7 @@
       beaker:
         reagents:
         - ReagentId: Oxygen
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -430,7 +430,7 @@
       beaker:
         reagents:
         - ReagentId: PlantBGone
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240
 
 - type: entity
   parent: Jug
@@ -445,4 +445,4 @@
       beaker:
         reagents:
         - ReagentId: WeldingFuel
-          Quantity: 200
+          Quantity: 240 # Wayfarer: 200<240

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -24,7 +24,7 @@
   - type: SolutionContainerManager
     solutions:
       beaker:
-        maxVol: 50
+        maxVol: 60 # Wayfarer: 50<60
   - type: MixableSolution
     solution: beaker
   - type: FitsInDispenser
@@ -229,7 +229,7 @@
   - type: SolutionContainerManager
     solutions:
       beaker:
-        maxVol: 100
+        maxVol: 120 # Wayfarer: 100<120
   - type: Appearance
   - type: SolutionContainerVisuals
     maxFillLevels: 6
@@ -259,7 +259,7 @@
   - type: SolutionContainerManager
     solutions:
       beaker:
-        maxVol: 60
+        maxVol: 90 # Wayfarer: 60<90
         canReact: false
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
@@ -26,7 +26,7 @@
   - type: SolutionContainerManager
     solutions:
       bucket:
-        maxVol: 250
+        maxVol: 300 # Wayfarer: 250<300
   - type: MixableSolution
     solution: bucket
   - type: SolutionTransfer

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/chemical-containers.yml
@@ -9,7 +9,7 @@
     - type: SolutionContainerManager
       solutions:
         beaker:
-          maxVol: 400
+          maxVol: 420 # Wayfarer: 400<420
     - type: Sprite
       sprite: _NF/Objects/Specific/Chemistry/reinforced_jug.rsi
       layers:
@@ -374,7 +374,7 @@
       beaker:
         reagents:
         - ReagentId: Carbon
-          Quantity: 400
+          Quantity: 420 # Wayfarer: 400<420
 
 - type: entity
   parent: ReinforcedJug
@@ -389,7 +389,7 @@
       beaker:
         reagents:
         - ReagentId: Chlorine
-          Quantity: 400
+          Quantity: 420 # Wayfarer: 400<420
 
 - type: entity
   parent: ReinforcedJug
@@ -404,7 +404,7 @@
       beaker:
         reagents:
         - ReagentId: Ethanol
-          Quantity: 400
+          Quantity: 420 # Wayfarer: 400<420
 
 - type: entity
   parent: ReinforcedJug
@@ -419,7 +419,7 @@
       beaker:
         reagents:
         - ReagentId: Sugar
-          Quantity: 400
+          Quantity: 420 # Wayfarer: 400<420
 
 - type: entity
   parent: ReinforcedJug
@@ -434,7 +434,7 @@
       beaker:
         reagents:
         - ReagentId: Hydrogen
-          Quantity: 400
+          Quantity: 420 # Wayfarer: 400<420
 
 - type: entity
   parent: ReinforcedJug
@@ -449,7 +449,7 @@
       beaker:
         reagents:
         - ReagentId: Lithium
-          Quantity: 400
+          Quantity: 420 # Wayfarer: 400<420
 
 - type: entity
   parent: ReinforcedJug
@@ -464,7 +464,7 @@
       beaker:
         reagents:
         - ReagentId: Nitrogen
-          Quantity: 400
+          Quantity: 420 # Wayfarer: 400<420
 
 - type: entity
   parent: ReinforcedJug
@@ -479,7 +479,7 @@
       beaker:
         reagents:
         - ReagentId: Oxygen
-          Quantity: 400
+          Quantity: 420 # Wayfarer: 400<420
 
 - type: entity
   parent: ReinforcedJug
@@ -494,7 +494,7 @@
       beaker:
         reagents:
         - ReagentId: Phosphorus
-          Quantity: 400
+          Quantity: 420 # Wayfarer: 400<420
 
 - type: entity
   parent: ReinforcedJug
@@ -509,7 +509,7 @@
       beaker:
         reagents:
         - ReagentId: Potassium
-          Quantity: 400
+          Quantity: 420 # Wayfarer: 400<420
 
 - type: entity
   parent: ReinforcedJug
@@ -524,4 +524,4 @@
       beaker:
         reagents:
         - ReagentId: Silicon
-          Quantity: 400
+          Quantity: 420 # Wayfarer: 400<420


### PR DESCRIPTION
## About the PR
- Chemistry: Small/Large beakers bumped to 60/120
- Chemistry: Jugs bumped to 240
- Chemistry: Reinforced Jugs bumped to 420
- Chemistry: Cryostasis Beaker bumped to 90
- Chemistry: Filled Chemical Jug amounts bumped to new values
--
- Bartending: Shaker bumped to 120
- Bartending: Flasks bumped to 60
- Bartending: Mugs bumped to 25
- Botany: Bucket bumped to 300
- Etc: Water Bottle bumped to 60
- Etc: Fire Extinguisher bumped to 120
- Etc: Spray Bottle bumped to 120

First PR and first time touching YAML so LMK if I've missed anything

## Why / Balance
Common divisors make fluids easier rather than wasting 10u or 20u per container.

## Technical details
Just YAML

## How to test
Spawn the items, throw fluid in them.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [ ] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
:cl:
- tweak: Adjust container sizes to share a common divisor with chemistry reactions.
