### PR TITLE
Ship Pass - Velios, Veliola, Hermes

### DIFF
--- a/Resources/Maps/_Mono/Shuttles/hermes.yml
+++ b/Resources/Maps/_Mono/Shuttles/hermes.yml
@@ -2079,13 +2079,6 @@ entities:
     - type: Transform
       pos: 0.5,-10.5
       parent: 1
-- proto: MailTeleporter
-  entities:
-  - uid: 269
-    components:
-    - type: Transform
-      pos: 2.5,-7.5
-      parent: 1
 - proto: Multitool
   entities:
   - uid: 270

--- a/Resources/Maps/_Mono/Shuttles/velios.yml
+++ b/Resources/Maps/_Mono/Shuttles/velios.yml
@@ -3326,7 +3326,7 @@ entities:
     - type: Transform
       pos: 6.5,-0.5
       parent: 1
-- proto: SMESAdvanced
+- proto: SMESBasic
   entities:
   - uid: 428
     components:

--- a/Resources/Maps/_WF/Shuttles/Outlaw/veliola.yml
+++ b/Resources/Maps/_WF/Shuttles/Outlaw/veliola.yml
@@ -3782,7 +3782,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 4.5,1.5
       parent: 1
-- proto: SMESAdvanced
+- proto: SMESBasic
   entities:
   - uid: 482
     components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Exchanges the Advanced SMES on the Velios and Veliola for the Basic SMES.
Removes the mail teleporter from the Hermes.

## Why / Balance
Kind of a powerful roundstart thing for these two. Let's switch them back to basic SMESes, people can upgrade it themselves given how these spawn with autolathes.
As for the Hermes... As much as I love mail, it's better to encourage the mail carriers to return to Dusk.

## Technical details
Simple yml change.

## How to test
Spawn the respective ships. Ships spawn, changes are visible.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Advanced SMESes from the Velios and Veliola have been replaced with their basic counterparts.
- remove: The Mail Teleporter has been removed from the Hermes.