### PR TITLE
[Balance][Atmos] Increased gas drill speed and oxygen numbers

### DIFF
--- a/Resources/Prototypes/_NF/Atmos/deposits.yml
+++ b/Resources/Prototypes/_NF/Atmos/deposits.yml
@@ -2,7 +2,7 @@
 - type: gasDeposit
   id: AirLike
   gases:
-  -  5000,  7500  # oxygen
+  -  7500,  10000 # oxygen Wayfarer: 5000,  7500<7500,  10000
   - 15000, 20000  # nitrogen
   -     0,  1500  # carbon dioxide
   -     0,   200  # plasma
@@ -17,7 +17,7 @@
 - type: gasDeposit
   id: MostlyNitrogen
   gases:
-  -     0,  2000  # oxygen
+  -     0,  3000  # oxygen Wayfarer: 0,  2000<0,  3000
   - 20000, 25000  # nitrogen
   -     0,  1500  # carbon dioxide
   -     0,   200  # plasma
@@ -32,7 +32,7 @@
 - type: gasDeposit
   id: MostlyOxygen
   gases:
-  - 20000, 25000  # oxygen
+  - 25000, 30000  # oxygen Wayfarer: 20000,  25000<25000,  30000
   -     0,  2000  # nitrogen
   -     0,  1500  # carbon dioxide
   -     0,   200  # plasma
@@ -122,7 +122,7 @@
 - type: gasDeposit
   id: MuddleEven
   gases:
-  -  2000,  4000  # oxygen
+  -  4000,  6000  # oxygen Wayfarer: 2000,  4000<4000,  6000
   -  2000,  4000  # nitrogen
   -  2000,  4000  # carbon dioxide
   -  2000,  4000  # plasma

--- a/Resources/Prototypes/_NF/Atmos/deposits.yml
+++ b/Resources/Prototypes/_NF/Atmos/deposits.yml
@@ -2,7 +2,7 @@
 - type: gasDeposit
   id: AirLike
   gases:
-  -  7500,  10000 # oxygen Wayfarer: 5000,  7500<7500,  10000
+  -  6500,  9000 # oxygen Wayfarer: 5000,  7500<6500,  9000
   - 15000, 20000  # nitrogen
   -     0,  1500  # carbon dioxide
   -     0,   200  # plasma
@@ -32,7 +32,7 @@
 - type: gasDeposit
   id: MostlyOxygen
   gases:
-  - 25000, 30000  # oxygen Wayfarer: 20000,  25000<25000,  30000
+  - 21000, 26000  # oxygen Wayfarer: 20000,  25000<21000,  26000
   -     0,  2000  # nitrogen
   -     0,  1500  # carbon dioxide
   -     0,   200  # plasma
@@ -49,7 +49,7 @@
   gases:
   -     0,  2000  # oxygen
   -     0,  1500  # nitrogen
-  - 20000, 25000  # carbon dioxide
+  - 25000, 30000  # carbon dioxide Wayfarer: 20000,  25000<25000,  30000
   -     0,   200  # plasma
   -     0,    50  # tritium
   -     0,   500  # water vapor

--- a/Resources/Prototypes/_NF/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -85,9 +85,9 @@
   - type: Machine
     board: GasMiningDrillMachineCircuitboard
   - type: GasDepositExtractor
-    baseExtractionRate: 50 # 50 mol/s => 20 kmol in ~6.6 min
-    extractionRate: 50
-    extractionRateMultiplier: 1.2 # max rate: 86.4 mol/s => 20 kmol in ~3.9 min
+    baseExtractionRate: 75 # Wayfarer: 50<75
+    extractionRate: 75 # Wayfarer: 50<75
+    extractionRateMultiplier: 1.2 
     port: outlet
   - type: Fixtures
     fixtures:

--- a/Resources/Prototypes/_NF/Entities/World/Debris/asteroids.yml
+++ b/Resources/Prototypes/_NF/Entities/World/Debris/asteroids.yml
@@ -85,7 +85,7 @@
     - type: RandomEntityPopulator
       entries:
       - params:
-          prob: 0.72 # Wayfarer 0.66<0.72
+          prob: 0.72 # Wayfarer: 0.66<0.72
           min: 1
           max: 4
           canBeAirSealed: true

--- a/Resources/Prototypes/_NF/Entities/World/Debris/asteroids.yml
+++ b/Resources/Prototypes/_NF/Entities/World/Debris/asteroids.yml
@@ -85,12 +85,12 @@
     - type: RandomEntityPopulator
       entries:
       - params:
-          prob: 0.66
+          prob: 0.72 # Wayfarer 0.66<0.72
           min: 1
           max: 4
           canBeAirSealed: true
         entries:
-        - id: GasDepositOxygen
+        - id: GasDepositOxygenVeryLarge # Wayfarer GasDepositOxygen<GasDepositOxygenVeryLarge
           orGroup: deposit
         - id: GasDepositOxygenLarge
           orGroup: deposit
@@ -98,7 +98,7 @@
           orGroup: deposit
         - id: GasDepositNitrogenLarge
           orGroup: deposit
-        - id: GasDepositAir
+        - id: GasDepositAirVeryLarge # Wayfarer GasDepositAir<GasDepositAirVeryLarge
           orGroup: deposit
         - id: GasDepositAirLarge
           orGroup: deposit

--- a/Resources/Prototypes/_NF/Entities/World/Debris/asteroids.yml
+++ b/Resources/Prototypes/_NF/Entities/World/Debris/asteroids.yml
@@ -98,7 +98,7 @@
           orGroup: deposit
         - id: GasDepositNitrogenLarge
           orGroup: deposit
-        - id: GasDepositAirVeryLarge # Wayfarer GasDepositAir<GasDepositAirVeryLarge
+        - id: GasDepositAirVeryLarge # Wayfarer: GasDepositAir<GasDepositAirVeryLarge
           orGroup: deposit
         - id: GasDepositAirLarge
           orGroup: deposit

--- a/Resources/Prototypes/_NF/Entities/World/Debris/asteroids.yml
+++ b/Resources/Prototypes/_NF/Entities/World/Debris/asteroids.yml
@@ -90,7 +90,7 @@
           max: 4
           canBeAirSealed: true
         entries:
-        - id: GasDepositOxygenVeryLarge # Wayfarer GasDepositOxygen<GasDepositOxygenVeryLarge
+        - id: GasDepositOxygenVeryLarge # Wayfarer: GasDepositOxygen<GasDepositOxygenVeryLarge
           orGroup: deposit
         - id: GasDepositOxygenLarge
           orGroup: deposit


### PR DESCRIPTION
## About the PR
Adds changes to the following things
Makes gas drill slightly faster
Adds Ice asteroids into rotation
Buffs oxygen deposits

## Why / Balance
The ghost of canister atmos still lingers and a lot of people are not willing to push for gas mining due to the abhorrent oxygen numbers. Makes gas mining less about sitting afk for 15 minutes while you wait for your large deposit to mine.

Adds ice roids into rotation since they were previously ignored most of the time

## Technical details
Yml changes commented under wayfarer:

## How to test
Spawn the gas deposits using your admin menu and mine them.
Notice how the ones that have oxygen have increased numbers

## Media


## Requirements
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)

## Breaking changes
None just yml changes

**Changelog**
:cl:
- tweak: Added more oxygen to ice asteroids
- tweak: Buffed gas drill speed
- tweak: Added more oxygen to oxygen deposits. and a ton more c02