### PR TITLE
[Outlaw] Uplink ammo changes

### DIFF
--- a/Resources/Locale/en-US/_WF/store/outlaw_uplink_catalogue.ftl
+++ b/Resources/Locale/en-US/_WF/store/outlaw_uplink_catalogue.ftl
@@ -37,8 +37,8 @@ uplink-outlaw-box35extincendiary-name = .35 Extended Incendiary Magazines
 uplink-outlaw-box35extincendiary-desc = A box full of extended pistol (.35 pistol, incendiary) magazines.
 uplink-outlaw-box35exturanium-name = .35 Extended Uranium Magazines
 uplink-outlaw-box35exturanium-desc = A box full of extended pistol (.35 pistol, uranium) magazines.
-uplink-outlaw-box35smg-name = .35 SMG Magazines
-uplink-outlaw-box35smg-desc = A box full of smg (.35 pistol) magazines.
+uplink-outlaw-box35smg-name = .35 SMG (Overpressure) Magazines
+uplink-outlaw-box35smg-desc = A box full of smg (.35 pistol, Overpressure) magazines.
 uplink-outlaw-box35smgrubber-name = .35 SMG ( Rubber ) Magazines
 uplink-outlaw-box35smgrubber-desc = A box full of smg (.35 pistol, rubber) magazines.
 

--- a/Resources/Prototypes/_WF/Catalog/Fills/Boxes/ammunition.yml
+++ b/Resources/Prototypes/_WF/Catalog/Fills/Boxes/ammunition.yml
@@ -219,7 +219,7 @@
   components:
   - type: StorageFill
     contents:
-    - id: NFMagazineSubMachineGun35
+    - id: NFMagazineSubMachineGun35Overpressure #WF: NFMagazineSubMachineGun35<NFMagazineSubMachineGun35Overpressure
       amount: 4
 
 #35 SMG Rubber C20

--- a/Resources/Prototypes/_WF/Catalog/outlaw_uplink_catalogue.yml
+++ b/Resources/Prototypes/_WF/Catalog/outlaw_uplink_catalogue.yml
@@ -689,22 +689,22 @@
       - OutlawUplinkBase
 
 #Ammo --
-#35 Stendos
-- type: listing
-  id: UplinkOutlawBox35Ext
-  name: uplink-outlaw-box35ext-name
-  description: uplink-outlaw-box35ext-desc
-  icon: { sprite: _NF/Objects/Storage/boxes.rsi, state: icon-magazine }
-  productEntity: MagBox35Ext
-  cost:
-    Doubloon: 1
-  categories:
-  - UplinkOutlawAmmo
-  conditions:
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
-      - OutlawUplinkBase
+#35 Stendos Commented out in favour of OverP
+#- type: listing
+#  id: UplinkOutlawBox35Ext
+#  name: uplink-outlaw-box35ext-name
+#  description: uplink-outlaw-box35ext-desc
+#  icon: { sprite: _NF/Objects/Storage/boxes.rsi, state: icon-magazine }
+#  productEntity: MagBox35Ext
+#  cost:
+#    Doubloon: 1
+#  categories:
+#  - UplinkOutlawAmmo
+#  conditions:
+#  - !type:StoreWhitelistCondition
+#    whitelist:
+#      tags:
+#      - OutlawUplinkBase
 
 #35 Stendos Rubber
 - type: listing
@@ -731,7 +731,7 @@
   icon: { sprite: _NF/Objects/Storage/boxes.rsi, state: icon-magazine }
   productEntity: MagBox35ExtOverpressure
   cost:
-    Doubloon: 2
+    Doubloon: 1 #WF: 2>1
   categories:
   - UplinkOutlawAmmo
   conditions:
@@ -748,7 +748,7 @@
   icon: { sprite: _NF/Objects/Storage/boxes.rsi, state: icon-magazine }
   productEntity: MagBox35ExtIncendiary
   cost:
-    Doubloon: 3
+    Doubloon: 2 #WF: 3>2
   categories:
   - UplinkOutlawAmmo
   conditions:
@@ -765,7 +765,7 @@
   icon: { sprite: _NF/Objects/Storage/boxes.rsi, state: icon-magazine }
   productEntity: MagBox35ExtUranium
   cost:
-    Doubloon: 5
+    Doubloon: 4 #WF: 4>3
   categories:
   - UplinkOutlawAmmo
   conditions:
@@ -808,22 +808,22 @@
       tags:
       - OutlawUplinkBase
 
-#45 Speedloader
-- type: listing
-  id: UplinkOutlawBox45Speedloader
-  name: uplink-outlaw-box45speedloader-name
-  description: uplink-outlaw-box45speedloader-desc
-  icon: { sprite: _NF/Objects/Storage/boxes.rsi, state: icon-magazine }
-  productEntity: MagBox45Speedloader
-  cost:
-    Doubloon: 1
-  categories:
-  - UplinkOutlawAmmo
-  conditions:
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
-      - OutlawUplinkBase
+#45 Speedloader WF: comment out
+#- type: listing
+#  id: UplinkOutlawBox45Speedloader
+#  name: uplink-outlaw-box45speedloader-name
+#  description: uplink-outlaw-box45speedloader-desc
+#  icon: { sprite: _NF/Objects/Storage/boxes.rsi, state: icon-magazine }
+#  productEntity: MagBox45Speedloader
+#  cost:
+#    Doubloon: 1
+#  categories:
+#  - UplinkOutlawAmmo
+#  conditions:
+#  - !type:StoreWhitelistCondition
+#    whitelist:
+#      tags:
+#      - OutlawUplinkBase
 
 #45 Speedloader Rubber
 - type: listing
@@ -850,7 +850,7 @@
   icon: { sprite: _NF/Objects/Storage/boxes.rsi, state: icon-magazine }
   productEntity: MagBox45SpeedloaderOverpressure
   cost:
-    Doubloon: 2
+    Doubloon: 1 #WF: 2>1
   categories:
   - UplinkOutlawAmmo
   conditions:
@@ -884,7 +884,7 @@
   icon: { sprite: _NF/Objects/Storage/boxes.rsi, state: icon-magazine }
   productEntity: MagBox45SpeedloaderUranium
   cost:
-    Doubloon: 5
+    Doubloon: 4 #WF: 5>4
   categories:
   - UplinkOutlawAmmo
   conditions:


### PR DESCRIPTION
## About the PR
Ammo felt a bit newb trappy and worthless to buy considering you can get a lathe with all this ammo for free. I've improved the ammo contents somewhat while reducing the price.

## Why / Balance
Improved ammo purchases a bit since they were useless.
they are now an Oh shit I didn't pack enough.

## Technical details
YML slop

## How to test
Spawn uplink, go purchase ammo, see the horrible default ones are not there anymore

## Media

## Requirements
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)

## Breaking changes
None just yml

**Changelog**
:cl:
- tweak: Changed outlaw uplink ammo to be slightly less pricier, slightly better.
