### PR TITLE
Prevents a bunch of jobs from having their title overwritten on ship purchase

### DIFF
--- a/Resources/Prototypes/_NF/Roles/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Civilian/janitor.yml
@@ -22,6 +22,11 @@
     prototype: NFWeaponRevolverInspector
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]
+  # Wayfarer
+  - !type:AddComponentSpecial
+    components:
+      - type: PreventShipyardTitleOverwrite
+  # End Wayfarer
   - !type:GiveItemOnHolidaySpecial
     holiday: FrontierBirthday
     prototype: FrontierBirthdayGift

--- a/Resources/Prototypes/_NF/Roles/Jobs/Civilian/valet.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Civilian/valet.yml
@@ -18,6 +18,11 @@
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]
+  # Wayfarer
+  - !type:AddComponentSpecial
+    components:
+      - type: PreventShipyardTitleOverwrite
+  # End Wayfarer
   - !type:GiveItemOnHolidaySpecial
     holiday: FrontierBirthday
     prototype: FrontierBirthdayGift

--- a/Resources/Prototypes/_NF/Roles/Jobs/Engineering/plant_technician.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Engineering/plant_technician.yml
@@ -17,6 +17,11 @@
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant, NFSDTrackingImplant ]
+  # Wayfarer
+  - !type:AddComponentSpecial
+    components:
+      - type: PreventShipyardTitleOverwrite
+  # End Wayfarer
   - !type:GiveItemOnHolidaySpecial
     holiday: FrontierBirthday
     prototype: FrontierBirthdayGift

--- a/Resources/Prototypes/_WF/Roles/Jobs/Medical/emergencyresponder.yml
+++ b/Resources/Prototypes/_WF/Roles/Jobs/Medical/emergencyresponder.yml
@@ -20,6 +20,9 @@
   special:
   - !type:AddImplantSpecial
     implants: [ TrackingImplant ]
+  - !type:AddComponentSpecial
+    components:
+      - type: PreventShipyardTitleOverwrite
   - !type:GiveItemOnHolidaySpecial
     holiday: FrontierBirthday
     prototype: FrontierBirthdayGift


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
As title says

## Why / Balance
Because janitors/valets/ptechs/ERs getting switched to "captain" creates a lot of confusion.

## Technical details
yaml slop

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Other Dusk Jobs should no longer have their titles overwritten to "Captain" on ship purchase.
