### PR TITLE
Re-adds the Sheetifier to its original Research Category, fixes crit implant tracker price.

### DIFF
--- a/Resources/Prototypes/_NF/Research/techtree.yml
+++ b/Resources/Prototypes/_NF/Research/techtree.yml
@@ -51,6 +51,7 @@
   cost: 5000
   recipeUnlocks:
   - AutolatheHyperConvectionMachineCircuitboard
+  - SheetifierMachineCircuitboard # Wayfarer
   - ProtolatheHyperConvectionMachineCircuitboard
   - CircuitImprinterHyperConvectionMachineCircuitboard
   technologyPrerequisites:

--- a/Resources/Prototypes/_WF/Entities/Objects/Devices/cartridges.yml
+++ b/Resources/Prototypes/_WF/Entities/Objects/Devices/cartridges.yml
@@ -15,8 +15,6 @@
         sprite: Objects/Specific/Medical/healthanalyzer.rsi
         state: icon
     - type: CriticalImplantTrackerCartridge
-    - type: StaticPrice
-      price: 1000
 
 - type: entity
   parent: NFBasePDACartridge


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title.

## Why / Balance
Sheetifier is a machine with limited uses that was disabled at some point, but it still has -one- use. So I guess if people want to use it, they can get the research for it, I suppose.

As for the crit implant tracker, it now inherits its parent's price, like all the other cartridges.

## Technical details
yaml slop

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added the sheet-master back to the research tables. Oh well. What a load o' sheet.
- tweak: Crit implant tracker's price is now standardized.
