### PR TITLE
Revert Threshold-Scrubbers (#284)

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AirFilterSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AirFilterSystem.cs
@@ -77,7 +77,7 @@ public sealed class AirFilterSystem : EntitySystem
 
         if (destination != null)
         {
-            _atmosphere.ScrubInto(removed, destination, gases, new Dictionary<Gas, float>());
+            _atmosphere.ScrubInto(removed, destination, gases);
         }
         else
         {

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
@@ -239,21 +239,12 @@ namespace Content.Server.Atmos.EntitySystems
         /// <summary>
         ///     Scrubs specified gases from a gas mixture into a <see cref="destination"/> gas mixture.
         /// </summary>
-        public void ScrubInto(GasMixture mixture, GasMixture destination, IReadOnlyCollection<Gas> filterGases, IReadOnlyDictionary<Gas, float> filterLimits)
+        public void ScrubInto(GasMixture mixture, GasMixture destination, IReadOnlyCollection<Gas> filterGases)
         {
             var buffer = new GasMixture(mixture.Volume){Temperature = mixture.Temperature};
-            var scrubGas = new Dictionary<Gas, bool>();
-            var totalMoles = mixture.TotalMoles;
 
             foreach (var gas in filterGases)
             {
-                // If a gas filter limit is in place, and the filter limit is below the target, don't scrub
-                if (filterLimits.ContainsKey(gas) && mixture.GetMoles(gas) / totalMoles <= filterLimits[gas] / 100)
-                {
-                    continue;
-                }
-
-                // If no filter limit is in place, filter all of it
                 buffer.AdjustMoles(gas, mixture.GetMoles(gas));
                 mixture.SetMoles(gas, 0f);
             }

--- a/Content.Server/Atmos/Piping/Unary/Components/GasVentScrubberComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasVentScrubberComponent.cs
@@ -26,9 +26,6 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         public HashSet<Gas> FilterGases = new(GasVentScrubberData.DefaultFilterGases);
 
         [DataField]
-        public Dictionary<Gas, float> FilterGasLimits = new(GasVentScrubberData.DefaultFilterGasLimits);
-
-        [DataField]
         public ScrubberPumpDirection PumpDirection { get; set; } = ScrubberPumpDirection.Scrubbing;
 
         /// <summary>
@@ -63,7 +60,6 @@ namespace Content.Server.Atmos.Piping.Unary.Components
                 Enabled = Enabled,
                 Dirty = IsDirty,
                 FilterGases = FilterGases,
-                FilterGasLimits = FilterGasLimits,
                 PumpDirection = PumpDirection,
                 VolumeRate = TransferRate,
                 WideNet = WideNet
@@ -83,13 +79,6 @@ namespace Content.Server.Atmos.Piping.Unary.Components
                 FilterGases.Clear();
                 foreach (var gas in data.FilterGases)
                     FilterGases.Add(gas);
-            }
-
-            if (!data.FilterGasLimits.SequenceEqual(FilterGasLimits))
-            {
-                FilterGasLimits.Clear();
-                foreach (var gas in data.FilterGasLimits.Keys)
-                    FilterGasLimits[gas] = data.FilterGasLimits[gas];
             }
         }
     }

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
@@ -95,13 +95,13 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
         private void Scrub(float timeDelta, GasVentScrubberComponent scrubber, GasMixture? tile, PipeNode outlet)
         {
-            Scrub(timeDelta, scrubber.TransferRate * _atmosphereSystem.PumpSpeedup(), scrubber.PumpDirection, scrubber.FilterGases, scrubber.FilterGasLimits, tile, outlet.Air);
+            Scrub(timeDelta, scrubber.TransferRate*_atmosphereSystem.PumpSpeedup(), scrubber.PumpDirection, scrubber.FilterGases, tile, outlet.Air);
         }
 
         /// <summary>
         /// True if we were able to scrub, false if we were not.
         /// </summary>
-        public bool Scrub(float timeDelta, float transferRate, ScrubberPumpDirection mode, HashSet<Gas> filterGases, Dictionary<Gas, float> filterLimits, GasMixture? tile, GasMixture destination)
+        public bool Scrub(float timeDelta, float transferRate, ScrubberPumpDirection mode, HashSet<Gas> filterGases, GasMixture? tile, GasMixture destination)
         {
             // Cannot scrub if tile is null or air-blocked.
             if (tile == null
@@ -120,7 +120,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
             if (mode == ScrubberPumpDirection.Scrubbing)
             {
-                _atmosphereSystem.ScrubInto(removed, destination, filterGases, filterLimits);
+                _atmosphereSystem.ScrubInto(removed, destination, filterGases);
 
                 // Remix the gases.
                 _atmosphereSystem.Merge(tile, removed);

--- a/Content.Server/Atmos/Portable/PortableScrubberSystem.cs
+++ b/Content.Server/Atmos/Portable/PortableScrubberSystem.cs
@@ -163,7 +163,7 @@ namespace Content.Server.Atmos.Portable
 
         private bool Scrub(float timeDelta, PortableScrubberComponent scrubber, GasMixture? tile)
         {
-            return _scrubberSystem.Scrub(timeDelta, scrubber.TransferRate * _atmosphereSystem.PumpSpeedup(), ScrubberPumpDirection.Scrubbing, scrubber.FilterGases, new(), tile, scrubber.Air);
+            return _scrubberSystem.Scrub(timeDelta, scrubber.TransferRate * _atmosphereSystem.PumpSpeedup(), ScrubberPumpDirection.Scrubbing, scrubber.FilterGases, tile, scrubber.Air);
         }
 
         private void UpdateAppearance(EntityUid uid, bool isFull, bool isRunning)

--- a/Content.Shared/Atmos/GasMixture.cs
+++ b/Content.Shared/Atmos/GasMixture.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -168,7 +168,7 @@ namespace Content.Shared.Atmos
             switch (ratio)
             {
                 case <= 0:
-                    return new GasMixture(Volume) { Temperature = Temperature };
+                    return new GasMixture(Volume){Temperature = Temperature};
                 case > 1:
                     ratio = 1;
                     break;

--- a/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
+++ b/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
@@ -10,7 +10,6 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
         public bool Dirty { get; set; }
         public bool IgnoreAlarms { get; set; } = false;
         public HashSet<Gas> FilterGases { get; set; } = new(DefaultFilterGases);
-        public Dictionary<Gas, float> FilterGasLimits { get; set; } = new(DefaultFilterGasLimits);
         public ScrubberPumpDirection PumpDirection { get; set; } = ScrubberPumpDirection.Scrubbing;
         public float VolumeRate { get; set; } = 200f;
         public bool WideNet { get; set; } = false;
@@ -18,7 +17,6 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
 
         public static HashSet<Gas> DefaultFilterGases = new()
         {
-            Gas.Nitrogen, // Limited by the filter limits below, will only scrub if above 80%
             Gas.CarbonDioxide,
             Gas.Plasma,
             Gas.Tritium,
@@ -27,11 +25,6 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             Gas.NitrousOxide,
             Gas.Frezon,
             Gas.Helium //Frontier
-        };
-
-        public static Dictionary<Gas, float> DefaultFilterGasLimits = new()
-        {
-            { Gas.Nitrogen, 80 }
         };
 
         // Presets for 'dumb' air alarm modes

--- a/Resources/Locale/en-US/_DV/phrases/subjects.ftl
+++ b/Resources/Locale/en-US/_DV/phrases/subjects.ftl
@@ -64,7 +64,6 @@ phrase-nitrogen = nitrogen
 phrase-oxygen = oxygen
 phrase-rcd = RCD
 phrase-rtg = RTG
-phrase-scrub = scrub
 phrase-scrubber = scrubber
 phrase-singulo = singularity
 phrase-smes = SMES

--- a/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
+++ b/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
@@ -68,8 +68,6 @@ air-alarm-ui-widget-copy = Copy settings to similar devices
 air-alarm-ui-widget-copy-tooltip = Copies the settings of this device to all devices in this air alarm tab.
 air-alarm-ui-widget-ignore = Ignore
 air-alarm-ui-atmos-net-device-label = Address: {$address}
-air-alarm-ui-atmos-gas-filter-percentage-tooltip = Scrub this gas only if the percentage of this gas is higher than this amount. Zero is default behavoir.
-air-alarm-ui-atmos-gas-filter-above = when above (%)
 
 ### Vent pumps
 


### PR DESCRIPTION
This reverts commit ecad713084ed407d6ed7b93dd503bf2b78ecedef, reversing changes made to 8b4baeefe3a3bc3b4a5f8bf025a2a7a4c23a04d1.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title.

## Why / Balance
Disfunctional. Was broken at some point in april according to git blame, but no one bothered to fix it, not that we were using it anyway, plus it makes a lot of uncommented changes to the base namespace that are -not- from Wizden OR DV.

I started looking into this because setting a scrubber to filter nitrogen doesn't let it filter nitrogen, lo and behold, it was because of these changes.

Here's how our current thing looks like.

<img width="599" height="634" alt="image" src="https://github.com/user-attachments/assets/b93c151a-76d5-41a5-b3c0-d2a620135638" />

Notice how the thresholds are absent and nitrogen is selected, but nitrogen in the room wasn't being filtered.

After this PR, setting them to filter nitrogen lets them filter that gas again.

<img width="468" height="452" alt="image" src="https://github.com/user-attachments/assets/f2fae7a6-7df1-4631-b65c-114c012bc10d" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
