### PR TITLE
Stamina Resistance for BOTH Sides

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -271,6 +271,8 @@
     clothingPrototype: ClothingHeadHelmetHardsuitNfsdCombat
   - type: ExplosionResistance
     damageCoefficient: 0.4
+  - type: StaminaResistance # Wayfarer
+    damageCoefficient: 0.75
   - type: Armor
     modifiers:
       coefficients:
@@ -281,8 +283,8 @@
         Radiation: 0.4
         Caustic: 0.6
   - type: ClothingSpeedModifier
-    walkModifier: 0.85
-    sprintModifier: 0.75
+    walkModifier: 0.90 # Wayfarer: 0.85<0.90
+    sprintModifier: 0.85 # Wayfarer: 0.75<0.85
 
 #Security Command Hardsuit
 - type: entity
@@ -299,6 +301,8 @@
     clothingPrototype: ClothingHeadHelmetHardsuitNfsdCommand
   - type: ExplosionResistance
     damageCoefficient: 0.4
+  - type: StaminaResistance # Wayfarer
+    damageCoefficient: 0.75
   - type: Armor
     modifiers:
       coefficients:
@@ -309,8 +313,8 @@
         Radiation: 0.4
         Caustic: 0.6
   - type: ClothingSpeedModifier
-    walkModifier: 0.85
-    sprintModifier: 0.75
+    walkModifier: 0.90 # Wayfarer: 0.85<0.90
+    sprintModifier: 0.85 # Wayfarer: 0.75<0.85
 
 # SCAF hardsuit
 - type: entity
@@ -320,7 +324,7 @@
   description: A green and brown combat hardsuit. Old yet sturdy nonetheless.
   components:
   - type: Sprite
-    sprite: _NF/Clothing/OuterClothing/Hardsuits/scaf.rsi 
+    sprite: _NF/Clothing/OuterClothing/Hardsuits/scaf.rsi
   - type: Clothing
     sprite: _NF/Clothing/OuterClothing/Hardsuits/scaf.rsi
   - type: Armor # Kept original scaf stats
@@ -393,6 +397,8 @@
     clothingPrototype: ClothingHeadHelmetHardsuitPirateElite
   - type: ExplosionResistance
     damageCoefficient: 0.4
+  - type: StaminaResistance # Wayfarer
+    damageCoefficient: 0.80
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/_WF/Entities/Clothing/OuterClothing/Hardsuits/hardsuits.yml
+++ b/Resources/Prototypes/_WF/Entities/Clothing/OuterClothing/Hardsuits/hardsuits.yml
@@ -46,6 +46,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.5
+  - type: StaminaResistance
+    damageCoefficient: 0.85
   - type: Armor
     modifiers:
       coefficients:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Alright, hear me out here. This PR adds stamina resist to the most common PvP hardsuits in the game that are not blood-red and elite. 
CGP actually has a option with resist now too, while making their combat hardsuit not completely slow as hell.
None of the suits changed had stam resist originally. Numbers selected based off of stats and to not invalidate the BR or Elite.

**Numbers:**
outlaw combat - **15**
pirate elite - **20**
cgp - **25**
blood-red - **(25)**
Elite - **(40)**

I list the elite and blood-red for comparison. They are (untouched) but the most common combat suits seen, they are important for the conversation.

Reminder: CGP does not get to use Hyperzine.

## Why / Balance
This shakes up blood-red criminal meta, giving other more viable options. 
Blood-red is fast as hell, boasting a solid base for pretty much all hardsuits to be compared against.
Elite is still strongest when it comes to stamina and speed but that is fine.
CGP had no way to attain stun resist.... this is obviously not good and has caused some issues with the recent rebuff of rubber ammo.

## Technical details
Yaml

## How to test
Hardsuits baby

## Media
<img width="432" height="362" alt="image" src="https://github.com/user-attachments/assets/ad8cb63b-a871-41dc-bece-1259cace16f1" />
<img width="426" height="360" alt="image" src="https://github.com/user-attachments/assets/58b1cc43-89aa-4ba7-8763-98236a33ee52" />
<img width="432" height="356" alt="image" src="https://github.com/user-attachments/assets/e40243d6-8bdb-402e-a73f-ae17e1435e23" />

**Unchanged:**
<img width="388" height="340" alt="image" src="https://github.com/user-attachments/assets/f91d103d-6746-43c0-854d-3e47d9fae981" />
<img width="393" height="376" alt="image" src="https://github.com/user-attachments/assets/ea330399-c1da-4aea-bab5-f4fa29f05e5e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- add: Added stamina resist to high-tier outlaw hardsuits!
- add: Added stamina resist to CGP combat hardsuits!
- tweak: CGP combat hardsuit speed reduction lowered slightly.