### PR TITLE
Velios and Veliola Ship Pass 2

### DIFF
--- a/Resources/Locale/en-US/_WF/Guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_WF/Guidebook/guides.ftl
@@ -55,4 +55,5 @@ guide-entry-shipyard-swan = Swan
 guide-entry-shipyard-moppet = Moppet
 guide-entry-shipyard-kobold = Kobold
 guide-entry-shipyard-manta = Manta
+guide-entry-shipyard-velios = Velios
 guide-entry-shipyard-veliola = Veliola

--- a/Resources/Maps/_Mono/Shuttles/velios.yml
+++ b/Resources/Maps/_Mono/Shuttles/velios.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 267.3.0
   forkId: ""
   forkVersion: ""
-  time: 07/12/2026 06:08:27
-  entityCount: 570
+  time: 07/12/2026 18:52:42
+  entityCount: 580
 maps: []
 grids:
 - 1
@@ -51,7 +51,7 @@ entities:
           version: 7
         0,-1:
           ind: 0,-1
-          tiles: AgAAAAAAAAIAAAAAAAACAAAAAAAABwAAAAAAAAIAAAAAAAAIAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAcAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAPAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAACAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAADwAAAAAAAA8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPAAAAAAAADwAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAA8AAAAAAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAAAAA8AAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAA8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAAAAAkAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAAAAAKAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAEQAAAAAAABEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAAAEQAAAAAAABEAAAAAAAAAAAAAAAAAAAAAAAAAABEAAAAAAAAAAAAAAAAADwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAEQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAAAAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAAOAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADgAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAEgAAAAAAABMAAAAAAAASAAAAAAAADQAAAAAAAAAAAAAAAAANAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAABIAAAAAAAASAAAAAAAAEgAAAAAAAA0AAAAAAAAAAAAAAAAADgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAEgAAAAAAABIAAAAAAAANAAAAAAAAAAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADgAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAAAAAAAAAADwAAAAAAAAEAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAA==
+          tiles: AgAAAAAAAAIAAAAAAAACAAAAAAAABwAAAAAAAAoAAAAAAAAIAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAcAAAAAAAAKAAAAAAAACgAAAAAAAAAAAAAAAAAPAAAAAAAAAAAAAAAAAAoAAAAAAAAKAAAAAAAACAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAADwAAAAAAAA8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPAAAAAAAADwAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAA8AAAAAAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAAAAA8AAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAA8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAAAAAkAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAAAAAKAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAEQAAAAAAABEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAAAEQAAAAAAABEAAAAAAAAAAAAAAAAAAAAAAAAAABEAAAAAAAAAAAAAAAAADwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAEQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAAAAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAAOAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADgAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAEgAAAAAAABMAAAAAAAASAAAAAAAADQAAAAAAAAAAAAAAAAANAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAABIAAAAAAAASAAAAAAAAEgAAAAAAAA0AAAAAAAAAAAAAAAAADgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAEgAAAAAAABIAAAAAAAANAAAAAAAAAAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADgAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAAAAAAAAAADwAAAAAAAAEAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAA==
           version: 7
         -1,-1:
           ind: -1,-1
@@ -313,6 +313,7 @@ entities:
             1: 16384
           0,-4:
             2: 24
+            1: 96
             0: 26112
           0,-3:
             0: 17
@@ -330,20 +331,21 @@ entities:
             0: 33792
             1: 16384
           1,-4:
+            1: 193
             0: 52240
             2: 2
           1,-3:
             2: 30577
           1,-2:
             2: 65063
+          2,-4:
+            2: 16
           2,-3:
             0: 529
             1: 16418
           2,-2:
             2: 30481
             0: 4
-          2,-4:
-            2: 16
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
@@ -957,6 +959,31 @@ entities:
     components:
     - type: Transform
       pos: 0.5,3.5
+      parent: 1
+  - uid: 571
+    components:
+    - type: Transform
+      pos: 6.5,-14.5
+      parent: 1
+  - uid: 572
+    components:
+    - type: Transform
+      pos: 1.5,-14.5
+      parent: 1
+  - uid: 573
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 1
+  - uid: 574
+    components:
+    - type: Transform
+      pos: 4.5,-15.5
+      parent: 1
+  - uid: 575
+    components:
+    - type: Transform
+      pos: 7.5,-14.5
       parent: 1
 - proto: Autolathe
   entities:
@@ -1835,87 +1862,22 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        429:
-        - - device-button-3
-          - Toggle
-        427:
-        - - device-button-3
-          - Toggle
-        425:
-        - - device-button-3
-          - Toggle
-        426:
+        430:
         - - device-button-3
           - Toggle
         428:
         - - device-button-3
           - Toggle
-        455:
-        - - device-button-1
-          - On
-        - - device-button-2
-          - Off
-        459:
-        - - device-button-1
-          - On
-        - - device-button-2
-          - Off
-        457:
-        - - device-button-1
-          - On
-        - - device-button-2
-          - Off
-        449:
-        - - device-button-1
-          - On
-        - - device-button-2
-          - Off
-        447:
-        - - device-button-1
-          - On
-        - - device-button-2
-          - Off
-        453:
-        - - device-button-1
-          - On
-        - - device-button-2
-          - Off
-        454:
-        - - device-button-1
-          - On
-        - - device-button-2
-          - Off
-        462:
-        - - device-button-1
-          - On
-        - - device-button-2
-          - Off
-        461:
-        - - device-button-1
-          - On
-        - - device-button-2
-          - Off
-        452:
-        - - device-button-1
-          - On
-        - - device-button-2
-          - Off
-        451:
-        - - device-button-1
-          - On
-        - - device-button-2
-          - Off
-        446:
-        - - device-button-1
-          - On
-        - - device-button-2
-          - Off
-        448:
-        - - device-button-1
-          - On
-        - - device-button-2
-          - Off
-        458:
+        426:
+        - - device-button-3
+          - Toggle
+        427:
+        - - device-button-3
+          - Toggle
+        429:
+        - - device-button-3
+          - Toggle
+        456:
         - - device-button-1
           - On
         - - device-button-2
@@ -1925,7 +1887,72 @@ entities:
           - On
         - - device-button-2
           - Off
-        456:
+        458:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        450:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        448:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        454:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        455:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        463:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        462:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        453:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        452:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        447:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        449:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        459:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        461:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        457:
         - - device-button-1
           - On
         - - device-button-2
@@ -1940,7 +1967,7 @@ entities:
           - Off
         - - device-button-1
           - On
-        450:
+        451:
         - - device-button-1
           - On
         - - device-button-2
@@ -2945,6 +2972,31 @@ entities:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
+  - uid: 576
+    components:
+    - type: Transform
+      pos: 6.5,-14.5
+      parent: 1
+  - uid: 577
+    components:
+    - type: Transform
+      pos: 1.5,-14.5
+      parent: 1
+  - uid: 578
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 1
+  - uid: 579
+    components:
+    - type: Transform
+      pos: 4.5,-15.5
+      parent: 1
+  - uid: 580
+    components:
+    - type: Transform
+      pos: 7.5,-14.5
+      parent: 1
 - proto: GrilleDiagonal
   entities:
   - uid: 362
@@ -3169,14 +3221,14 @@ entities:
       parent: 1
 - proto: NFHolopadShip
   entities:
-  - uid: 570
+  - uid: 396
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 1
 - proto: NitrogenCanister
   entities:
-  - uid: 396
+  - uid: 397
     components:
     - type: Transform
       anchored: True
@@ -3186,14 +3238,14 @@ entities:
       bodyType: Static
 - proto: OperatingTable
   entities:
-  - uid: 397
+  - uid: 398
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
 - proto: OxygenCanister
   entities:
-  - uid: 398
+  - uid: 399
     components:
     - type: Transform
       anchored: True
@@ -3203,19 +3255,19 @@ entities:
       bodyType: Static
 - proto: PoweredLEDSmallLight
   entities:
-  - uid: 399
+  - uid: 400
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-6.5
       parent: 1
-  - uid: 400
+  - uid: 401
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-7.5
       parent: 1
-  - uid: 401
+  - uid: 402
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3223,7 +3275,7 @@ entities:
       parent: 1
 - proto: PoweredlightGreen
   entities:
-  - uid: 402
+  - uid: 403
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3231,30 +3283,30 @@ entities:
       parent: 1
 - proto: PoweredlightLED
   entities:
-  - uid: 403
+  - uid: 404
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-2.5
       parent: 1
-  - uid: 404
+  - uid: 405
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,0.5
       parent: 1
-  - uid: 405
+  - uid: 406
     components:
     - type: Transform
       pos: 6.5,-3.5
       parent: 1
-  - uid: 406
+  - uid: 407
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,1.5
       parent: 1
-  - uid: 407
+  - uid: 408
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3262,7 +3314,7 @@ entities:
       parent: 1
 - proto: PoweredlightRed
   entities:
-  - uid: 408
+  - uid: 409
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3270,7 +3322,7 @@ entities:
       parent: 1
 - proto: PoweredWarmSmallLight
   entities:
-  - uid: 409
+  - uid: 410
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3278,12 +3330,12 @@ entities:
       parent: 1
 - proto: Railing
   entities:
-  - uid: 410
+  - uid: 411
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 411
+  - uid: 412
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3291,64 +3343,64 @@ entities:
       parent: 1
 - proto: RailingCorner
   entities:
-  - uid: 412
+  - uid: 413
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
 - proto: RailingCornerSmall
   entities:
-  - uid: 413
+  - uid: 414
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-7.5
       parent: 1
-  - uid: 414
+  - uid: 415
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
 - proto: ReinforcedWindow
   entities:
-  - uid: 415
+  - uid: 416
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 416
+  - uid: 417
     components:
     - type: Transform
       pos: 6.5,7.5
       parent: 1
-  - uid: 417
+  - uid: 418
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
-  - uid: 418
+  - uid: 419
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 1
-  - uid: 419
+  - uid: 420
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 420
+  - uid: 421
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
 - proto: ReinforcedWindowDiagonal
   entities:
-  - uid: 421
+  - uid: 422
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 422
+  - uid: 423
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3356,42 +3408,42 @@ entities:
       parent: 1
 - proto: RollerBed
   entities:
-  - uid: 423
+  - uid: 424
     components:
     - type: Transform
       pos: 7.5,-5.5
       parent: 1
 - proto: RollerBedSpawnFolded
   entities:
-  - uid: 424
+  - uid: 425
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 1
 - proto: ShuttersNormalOpen
   entities:
-  - uid: 425
+  - uid: 426
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 1
-  - uid: 426
+  - uid: 427
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
-  - uid: 427
+  - uid: 428
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 428
+  - uid: 429
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,7.5
       parent: 1
-  - uid: 429
+  - uid: 430
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3399,196 +3451,196 @@ entities:
       parent: 1
 - proto: SinkWide
   entities:
-  - uid: 430
+  - uid: 431
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
-  - uid: 431
+  - uid: 432
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 1
 - proto: SMESBasic
   entities:
-  - uid: 432
+  - uid: 433
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 433
+  - uid: 434
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
 - proto: StasisBed
   entities:
-  - uid: 434
+  - uid: 435
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
 - proto: SubstationWallBasic
   entities:
-  - uid: 435
+  - uid: 436
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 436
+  - uid: 437
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 1
-  - uid: 437
+  - uid: 438
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 1
-  - uid: 438
+  - uid: 439
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 1
-  - uid: 439
+  - uid: 440
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 1
-  - uid: 440
+  - uid: 441
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 441
+  - uid: 442
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 442
+  - uid: 443
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
 - proto: TableReinforcedGlass
   entities:
-  - uid: 443
+  - uid: 444
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 444
+  - uid: 445
     components:
     - type: Transform
       pos: 9.5,-3.5
       parent: 1
 - proto: TelecomServerFilledShuttle
   entities:
-  - uid: 445
+  - uid: 446
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
 - proto: Thruster
   entities:
-  - uid: 446
+  - uid: 447
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-9.5
       parent: 1
-  - uid: 447
+  - uid: 448
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-9.5
       parent: 1
-  - uid: 448
+  - uid: 449
     components:
     - type: Transform
       pos: 10.5,-1.5
       parent: 1
-  - uid: 449
+  - uid: 450
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 450
+  - uid: 451
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-14.5
       parent: 1
-  - uid: 451
+  - uid: 452
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-10.5
       parent: 1
-  - uid: 452
+  - uid: 453
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-11.5
       parent: 1
-  - uid: 453
+  - uid: 454
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-10.5
       parent: 1
-  - uid: 454
+  - uid: 455
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-11.5
       parent: 1
-  - uid: 455
+  - uid: 456
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 456
+  - uid: 457
     components:
     - type: Transform
       pos: 7.5,5.5
       parent: 1
-  - uid: 457
+  - uid: 458
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-0.5
       parent: 1
-  - uid: 458
+  - uid: 459
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-0.5
       parent: 1
-  - uid: 459
+  - uid: 460
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 460
+  - uid: 461
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 1
 - proto: ThrusterLarge
   entities:
-  - uid: 461
+  - uid: 462
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-13.5
       parent: 1
-  - uid: 462
+  - uid: 463
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3596,472 +3648,472 @@ entities:
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 463
+  - uid: 464
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 464
+  - uid: 465
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
-  - uid: 465
+  - uid: 466
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 466
+  - uid: 467
     components:
     - type: Transform
       pos: 10.5,-3.5
       parent: 1
-  - uid: 467
+  - uid: 468
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 468
+  - uid: 469
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 469
+  - uid: 470
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 470
+  - uid: 471
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 471
+  - uid: 472
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 472
+  - uid: 473
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 473
+  - uid: 474
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 474
+  - uid: 475
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 475
+  - uid: 476
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 476
+  - uid: 477
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 477
+  - uid: 478
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 478
+  - uid: 479
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 479
+  - uid: 480
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 480
+  - uid: 481
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 481
+  - uid: 482
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 1
-  - uid: 482
+  - uid: 483
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 1
-  - uid: 483
+  - uid: 484
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 1
-  - uid: 484
+  - uid: 485
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 1
-  - uid: 485
+  - uid: 486
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 1
-  - uid: 486
+  - uid: 487
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 1
-  - uid: 487
+  - uid: 488
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 1
-  - uid: 488
+  - uid: 489
     components:
     - type: Transform
       pos: 8.5,0.5
       parent: 1
-  - uid: 489
+  - uid: 490
     components:
     - type: Transform
       pos: 8.5,-0.5
       parent: 1
-  - uid: 490
+  - uid: 491
     components:
     - type: Transform
       pos: 8.5,-1.5
       parent: 1
-  - uid: 491
+  - uid: 492
     components:
     - type: Transform
       pos: 9.5,-1.5
       parent: 1
-  - uid: 492
+  - uid: 493
     components:
     - type: Transform
       pos: 9.5,-2.5
       parent: 1
-  - uid: 493
+  - uid: 494
     components:
     - type: Transform
       pos: 9.5,-6.5
       parent: 1
-  - uid: 494
+  - uid: 495
     components:
     - type: Transform
       pos: 9.5,-8.5
       parent: 1
-  - uid: 495
+  - uid: 496
     components:
     - type: Transform
       pos: 9.5,-7.5
       parent: 1
-  - uid: 496
+  - uid: 497
     components:
     - type: Transform
       pos: 8.5,-9.5
       parent: 1
-  - uid: 497
+  - uid: 498
     components:
     - type: Transform
       pos: 7.5,-9.5
       parent: 1
-  - uid: 498
+  - uid: 499
     components:
     - type: Transform
       pos: 7.5,-10.5
       parent: 1
-  - uid: 499
+  - uid: 500
     components:
     - type: Transform
       pos: 7.5,-11.5
       parent: 1
-  - uid: 500
+  - uid: 501
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 1
-  - uid: 501
+  - uid: 502
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 502
+  - uid: 503
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 1
-  - uid: 503
+  - uid: 504
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 1
-  - uid: 504
+  - uid: 505
     components:
     - type: Transform
       pos: 3.5,-13.5
       parent: 1
-  - uid: 505
+  - uid: 506
     components:
     - type: Transform
       pos: 4.5,-13.5
       parent: 1
-  - uid: 506
+  - uid: 507
     components:
     - type: Transform
       pos: 5.5,-13.5
       parent: 1
-  - uid: 507
+  - uid: 508
     components:
     - type: Transform
       pos: 5.5,-14.5
       parent: 1
-  - uid: 508
+  - uid: 509
     components:
     - type: Transform
       pos: 0.5,-12.5
       parent: 1
-  - uid: 509
+  - uid: 510
     components:
     - type: Transform
       pos: 0.5,-13.5
       parent: 1
-  - uid: 510
+  - uid: 511
     components:
     - type: Transform
       pos: 8.5,-12.5
       parent: 1
-  - uid: 511
+  - uid: 512
     components:
     - type: Transform
       pos: 8.5,-13.5
       parent: 1
-  - uid: 512
+  - uid: 513
     components:
     - type: Transform
       pos: 3.5,-14.5
       parent: 1
-  - uid: 513
+  - uid: 514
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
-  - uid: 514
+  - uid: 515
     components:
     - type: Transform
       pos: 8.5,-8.5
       parent: 1
-  - uid: 515
+  - uid: 516
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
-  - uid: 516
+  - uid: 517
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 1
-  - uid: 517
+  - uid: 518
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 518
+  - uid: 519
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 1
-  - uid: 519
+  - uid: 520
     components:
     - type: Transform
       pos: 5.5,-11.5
       parent: 1
-  - uid: 520
+  - uid: 521
     components:
     - type: Transform
       pos: 3.5,-12.5
       parent: 1
-  - uid: 521
+  - uid: 522
     components:
     - type: Transform
       pos: 6.5,-11.5
       parent: 1
-  - uid: 522
+  - uid: 523
     components:
     - type: Transform
       pos: 3.5,-11.5
       parent: 1
-  - uid: 523
+  - uid: 524
     components:
     - type: Transform
       pos: 5.5,-12.5
       parent: 1
-  - uid: 524
+  - uid: 525
     components:
     - type: Transform
       pos: 4.5,-12.5
       parent: 1
-  - uid: 525
+  - uid: 526
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
-  - uid: 526
+  - uid: 527
     components:
     - type: Transform
       pos: 7.5,-8.5
       parent: 1
-  - uid: 527
+  - uid: 528
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 528
+  - uid: 529
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 1
-  - uid: 529
+  - uid: 530
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 530
+  - uid: 531
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 1
-  - uid: 531
+  - uid: 532
     components:
     - type: Transform
       pos: 7.5,-7.5
       parent: 1
-  - uid: 532
+  - uid: 533
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 533
+  - uid: 534
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
-  - uid: 534
+  - uid: 535
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
-  - uid: 535
+  - uid: 536
     components:
     - type: Transform
       pos: 6.5,-6.5
       parent: 1
-  - uid: 536
+  - uid: 537
     components:
     - type: Transform
       pos: 7.5,-6.5
       parent: 1
-  - uid: 537
+  - uid: 538
     components:
     - type: Transform
       pos: 10.5,-6.5
       parent: 1
-  - uid: 538
+  - uid: 539
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 1
-  - uid: 539
+  - uid: 540
     components:
     - type: Transform
       pos: 10.5,-2.5
       parent: 1
-  - uid: 540
+  - uid: 541
     components:
     - type: Transform
       pos: 7.5,0.5
       parent: 1
-  - uid: 541
+  - uid: 542
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 542
+  - uid: 543
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 543
+  - uid: 544
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 544
+  - uid: 545
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 545
+  - uid: 546
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
-  - uid: 546
+  - uid: 547
     components:
     - type: Transform
       pos: 7.5,-2.5
       parent: 1
-  - uid: 547
+  - uid: 548
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 548
+  - uid: 549
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-  - uid: 549
+  - uid: 550
     components:
     - type: Transform
       pos: 8.5,-2.5
       parent: 1
-  - uid: 550
+  - uid: 551
     components:
     - type: Transform
       pos: 6.5,0.5
       parent: 1
-  - uid: 551
+  - uid: 552
     components:
     - type: Transform
       pos: 6.5,-2.5
       parent: 1
 - proto: WallReinforcedDiagonal
   entities:
-  - uid: 552
+  - uid: 553
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-14.5
       parent: 1
-  - uid: 553
+  - uid: 554
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-14.5
       parent: 1
-  - uid: 554
+  - uid: 555
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-15.5
       parent: 1
-  - uid: 555
+  - uid: 556
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4069,7 +4121,7 @@ entities:
       parent: 1
 - proto: WallWeaponCapacitorRecharger
   entities:
-  - uid: 556
+  - uid: 557
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4077,27 +4129,27 @@ entities:
       parent: 1
 - proto: WarpPoint
   entities:
-  - uid: 557
+  - uid: 558
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
 - proto: WeaponCapacitorRecharger
   entities:
-  - uid: 558
+  - uid: 559
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
 - proto: Windoor
   entities:
-  - uid: 559
+  - uid: 560
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-6.5
       parent: 1
-  - uid: 560
+  - uid: 561
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4105,49 +4157,49 @@ entities:
       parent: 1
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 561
+  - uid: 562
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,5.5
       parent: 1
-  - uid: 562
+  - uid: 563
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,2.5
       parent: 1
-  - uid: 563
+  - uid: 564
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 1
-  - uid: 564
+  - uid: 565
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-9.5
       parent: 1
-  - uid: 565
+  - uid: 566
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-9.5
       parent: 1
-  - uid: 566
+  - uid: 567
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-1.5
       parent: 1
-  - uid: 567
+  - uid: 568
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,2.5
       parent: 1
-  - uid: 568
+  - uid: 569
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4155,7 +4207,7 @@ entities:
       parent: 1
 - proto: Wrench
   entities:
-  - uid: 569
+  - uid: 570
     components:
     - type: Transform
       pos: 0.42960453,-6.564963

--- a/Resources/Maps/_Mono/Shuttles/velios.yml
+++ b/Resources/Maps/_Mono/Shuttles/velios.yml
@@ -2139,7 +2139,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-- proto: GasMixerFlipped
+- proto: GasMixerOnFlipped
   entities:
   - uid: 262
     components:

--- a/Resources/Maps/_Mono/Shuttles/velios.yml
+++ b/Resources/Maps/_Mono/Shuttles/velios.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 267.3.0
   forkId: ""
   forkVersion: ""
-  time: 05/26/2026 02:13:39
-  entityCount: 565
+  time: 07/12/2026 06:08:27
+  entityCount: 570
 maps: []
 grids:
 - 1
@@ -420,9 +420,9 @@ entities:
     - type: DeviceList
       devices:
       - 21
-      - 343
-      - 349
-      - 255
+      - 344
+      - 350
+      - 256
     - type: Fixtures
       fixtures: {}
   - uid: 3
@@ -435,11 +435,11 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
+      - 256
       - 255
       - 254
-      - 253
-      - 350
-      - 342
+      - 351
+      - 343
       - 20
     - type: Fixtures
       fixtures: {}
@@ -453,11 +453,11 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 257
-      - 253
+      - 258
+      - 254
       - 19
-      - 340
-      - 346
+      - 341
+      - 347
     - type: Fixtures
       fixtures: {}
   - uid: 5
@@ -470,11 +470,11 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 254
-      - 252
+      - 255
+      - 253
       - 22
-      - 351
-      - 344
+      - 352
+      - 345
     - type: Fixtures
       fixtures: {}
   - uid: 6
@@ -488,11 +488,11 @@ entities:
     - type: DeviceList
       devices:
       - 23
-      - 341
-      - 348
-      - 256
+      - 342
+      - 349
       - 257
-      - 252
+      - 258
+      - 253
     - type: Fixtures
       fixtures: {}
   - uid: 7
@@ -505,10 +505,10 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 256
+      - 257
       - 24
-      - 345
-      - 347
+      - 346
+      - 348
     - type: Fixtures
       fixtures: {}
 - proto: AirCanister
@@ -982,20 +982,19 @@ entities:
     - type: Transform
       pos: 1.5,-5.5
       parent: 1
-- proto: BoxFolderBlueEmpty
+- proto: BoxBeaker
   entities:
   - uid: 87
     components:
     - type: Transform
-      pos: 3.58267,7.422798
+      pos: 6.6041327,-3.5259535
       parent: 1
-- proto: ButtonFrameCaution
+- proto: BoxFolderBlueEmpty
   entities:
   - uid: 88
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,5.5
+      pos: 3.58267,7.422798
       parent: 1
 - proto: CableApcExtension
   entities:
@@ -1834,6 +1833,118 @@ entities:
     - type: Transform
       pos: 4.5,7.5
       parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        429:
+        - - device-button-3
+          - Toggle
+        427:
+        - - device-button-3
+          - Toggle
+        425:
+        - - device-button-3
+          - Toggle
+        426:
+        - - device-button-3
+          - Toggle
+        428:
+        - - device-button-3
+          - Toggle
+        455:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        459:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        457:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        449:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        447:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        453:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        454:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        462:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        461:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        452:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        451:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        446:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        448:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        458:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        460:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        456:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        375:
+        - - device-button-2
+          - Off
+        - - device-button-1
+          - On
+        374:
+        - - device-button-2
+          - Off
+        - - device-button-1
+          - On
+        450:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
@@ -1858,37 +1969,44 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
-- proto: CrateMedical
+- proto: CrateMaterialsBasicFilled
   entities:
   - uid: 245
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 1
+- proto: CrateMedical
+  entities:
+  - uid: 246
     components:
     - type: Transform
       pos: 6.5,-3.5
       parent: 1
 - proto: CryoPod
   entities:
-  - uid: 246
+  - uid: 247
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
 - proto: CryoxadoneBeakerSmall
   entities:
-  - uid: 247
+  - uid: 248
     components:
     - type: Transform
       pos: 2.3645182,-1.1745439
       parent: 1
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 248
+  - uid: 249
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 249
+  - uid: 250
     components:
     - type: Transform
       pos: 6.5,0.5
@@ -1897,7 +2015,7 @@ entities:
       fixtures: {}
 - proto: ExtinguisherCabinetFilled
   entities:
-  - uid: 250
+  - uid: 251
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1907,14 +2025,14 @@ entities:
       fixtures: {}
 - proto: FaxMachineShip
   entities:
-  - uid: 251
+  - uid: 252
     components:
     - type: Transform
-      pos: 4.5,5.5
+      pos: 3.5,6.5
       parent: 1
 - proto: FirelockGlass
   entities:
-  - uid: 252
+  - uid: 253
     components:
     - type: Transform
       pos: 5.5,-2.5
@@ -1923,7 +2041,7 @@ entities:
       deviceLists:
       - 6
       - 5
-  - uid: 253
+  - uid: 254
     components:
     - type: Transform
       pos: 3.5,-0.5
@@ -1932,7 +2050,7 @@ entities:
       deviceLists:
       - 4
       - 3
-  - uid: 254
+  - uid: 255
     components:
     - type: Transform
       pos: 5.5,0.5
@@ -1941,7 +2059,7 @@ entities:
       deviceLists:
       - 5
       - 3
-  - uid: 255
+  - uid: 256
     components:
     - type: Transform
       pos: 3.5,4.5
@@ -1950,7 +2068,7 @@ entities:
       deviceLists:
       - 3
       - 2
-  - uid: 256
+  - uid: 257
     components:
     - type: Transform
       pos: 5.5,-6.5
@@ -1959,7 +2077,7 @@ entities:
       deviceLists:
       - 6
       - 7
-  - uid: 257
+  - uid: 258
     components:
     - type: Transform
       pos: 4.5,-4.5
@@ -1970,14 +2088,14 @@ entities:
       - 4
 - proto: FloorDrain
   entities:
-  - uid: 258
+  - uid: 259
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 259
+  - uid: 260
     components:
     - type: Transform
       pos: 4.5,1.5
@@ -1986,7 +2104,7 @@ entities:
       fixtures: {}
 - proto: GasFilter
   entities:
-  - uid: 260
+  - uid: 261
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1996,7 +2114,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasMixerFlipped
   entities:
-  - uid: 261
+  - uid: 262
     components:
     - type: Transform
       pos: 3.5,-9.5
@@ -2008,7 +2126,7 @@ entities:
       inletOneConcentration: 0.22
 - proto: GasPassiveVent
   entities:
-  - uid: 262
+  - uid: 263
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2020,7 +2138,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeBend
   entities:
-  - uid: 263
+  - uid: 264
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2028,7 +2146,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 264
+  - uid: 265
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2036,7 +2154,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 265
+  - uid: 266
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2044,7 +2162,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 266
+  - uid: 267
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2052,7 +2170,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 267
+  - uid: 268
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2060,7 +2178,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 268
+  - uid: 269
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2068,7 +2186,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 269
+  - uid: 270
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2076,7 +2194,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 270
+  - uid: 271
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2086,7 +2204,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeBendAlt1
   entities:
-  - uid: 271
+  - uid: 272
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2094,7 +2212,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 272
+  - uid: 273
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2102,14 +2220,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 273
+  - uid: 274
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 274
+  - uid: 275
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2117,7 +2235,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 275
+  - uid: 276
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2125,14 +2243,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 276
+  - uid: 277
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 277
+  - uid: 278
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2140,7 +2258,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 278
+  - uid: 279
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2148,7 +2266,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 279
+  - uid: 280
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2156,7 +2274,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 280
+  - uid: 281
     components:
     - type: Transform
       pos: 4.5,-10.5
@@ -2165,14 +2283,14 @@ entities:
       color: '#990000FF'
 - proto: GasPipeFourway
   entities:
-  - uid: 281
+  - uid: 282
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 282
+  - uid: 283
     components:
     - type: Transform
       pos: 3.5,-4.5
@@ -2181,7 +2299,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeManifold
   entities:
-  - uid: 283
+  - uid: 284
     components:
     - type: Transform
       pos: 1.5,-4.5
@@ -2190,7 +2308,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeStraight
   entities:
-  - uid: 284
+  - uid: 285
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2198,74 +2316,66 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 285
+  - uid: 286
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 286
+  - uid: 287
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 287
+  - uid: 288
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 288
+  - uid: 289
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 289
+  - uid: 290
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 290
+  - uid: 291
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 291
+  - uid: 292
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 292
+  - uid: 293
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 293
-    components:
-    - type: Transform
-      pos: 3.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 294
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-5.5
+      pos: 3.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -2273,11 +2383,19 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,-5.5
+      pos: 1.5,-5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 296
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 297
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2285,7 +2403,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 297
+  - uid: 298
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2293,25 +2411,17 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 298
+  - uid: 299
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 299
-    components:
-    - type: Transform
-      pos: 5.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 300
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-4.5
+      pos: 5.5,-5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -2319,15 +2429,15 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 4.5,-4.5
+      pos: 6.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 302
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-3.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -2335,11 +2445,19 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 5.5,-2.5
+      pos: 5.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 304
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 305
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2349,18 +2467,10 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeStraightAlt1
   entities:
-  - uid: 305
-    components:
-    - type: Transform
-      pos: 3.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 306
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-3.5
+      pos: 3.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -2368,7 +2478,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,-2.5
+      pos: 3.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -2376,7 +2486,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,-0.5
+      pos: 3.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -2384,11 +2494,19 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,-1.5
+      pos: 3.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 310
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 311
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2396,28 +2514,28 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 311
+  - uid: 312
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 312
+  - uid: 313
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 313
+  - uid: 314
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 314
+  - uid: 315
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2425,7 +2543,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 315
+  - uid: 316
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2433,7 +2551,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 316
+  - uid: 317
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2441,7 +2559,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 317
+  - uid: 318
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2449,21 +2567,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 318
+  - uid: 319
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 319
+  - uid: 320
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 320
+  - uid: 321
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2471,21 +2589,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 321
+  - uid: 322
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 322
+  - uid: 323
     components:
     - type: Transform
       pos: 4.5,-12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 323
+  - uid: 324
     components:
     - type: Transform
       pos: 4.5,-13.5
@@ -2494,18 +2612,10 @@ entities:
       color: '#990000FF'
 - proto: GasPipeTJunction
   entities:
-  - uid: 324
-    components:
-    - type: Transform
-      pos: 3.5,-7.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 325
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,2.5
+      pos: 3.5,-7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -2513,7 +2623,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 0.5,-5.5
+      pos: 3.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -2521,11 +2631,19 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 0.5,-3.5
+      pos: 0.5,-5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 328
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 329
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2533,7 +2651,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 329
+  - uid: 330
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2543,7 +2661,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeTJunctionAlt1
   entities:
-  - uid: 330
+  - uid: 331
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2551,7 +2669,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 331
+  - uid: 332
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2559,7 +2677,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 332
+  - uid: 333
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2567,7 +2685,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 333
+  - uid: 334
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2575,7 +2693,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 334
+  - uid: 335
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2585,7 +2703,7 @@ entities:
       color: '#990000FF'
 - proto: GasPort
   entities:
-  - uid: 335
+  - uid: 336
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2593,7 +2711,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 336
+  - uid: 337
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2601,7 +2719,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 337
+  - uid: 338
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2611,7 +2729,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPressurePump
   entities:
-  - uid: 338
+  - uid: 339
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2621,7 +2739,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasThermoMachineFreezer
   entities:
-  - uid: 339
+  - uid: 340
     components:
     - type: Transform
       pos: 2.5,-1.5
@@ -2630,7 +2748,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasVentPump
   entities:
-  - uid: 340
+  - uid: 341
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2641,7 +2759,7 @@ entities:
       - 4
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 341
+  - uid: 342
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2652,7 +2770,7 @@ entities:
       - 6
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 342
+  - uid: 343
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2663,7 +2781,7 @@ entities:
       - 3
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 343
+  - uid: 344
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2674,7 +2792,7 @@ entities:
       - 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 344
+  - uid: 345
     components:
     - type: Transform
       pos: 5.5,-1.5
@@ -2684,7 +2802,7 @@ entities:
       - 5
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 345
+  - uid: 346
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2697,7 +2815,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 346
+  - uid: 347
     components:
     - type: Transform
       pos: 2.5,-4.5
@@ -2709,7 +2827,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 347
+  - uid: 348
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2722,7 +2840,7 @@ entities:
       color: '#990000FF'
     - type: AtmosPipeLayers
       pipeLayer: Secondary
-  - uid: 348
+  - uid: 349
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2735,7 +2853,7 @@ entities:
       color: '#990000FF'
     - type: AtmosPipeLayers
       pipeLayer: Secondary
-  - uid: 349
+  - uid: 350
     components:
     - type: Transform
       pos: 3.5,5.5
@@ -2750,7 +2868,7 @@ entities:
       edge: 0
     - type: AtmosPipeLayers
       pipeLayer: Secondary
-  - uid: 350
+  - uid: 351
     components:
     - type: Transform
       pos: 3.5,1.5
@@ -2765,7 +2883,7 @@ entities:
       edge: 0
     - type: AtmosPipeLayers
       pipeLayer: Secondary
-  - uid: 351
+  - uid: 352
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2780,117 +2898,117 @@ entities:
       pipeLayer: Secondary
 - proto: GravityGeneratorMini
   entities:
-  - uid: 352
+  - uid: 353
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 353
+  - uid: 354
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 1
-  - uid: 354
+  - uid: 355
     components:
     - type: Transform
       pos: 9.5,-10.5
       parent: 1
-  - uid: 355
+  - uid: 356
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 356
+  - uid: 357
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 1
-  - uid: 357
+  - uid: 358
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
-  - uid: 358
+  - uid: 359
     components:
     - type: Transform
       pos: 6.5,7.5
       parent: 1
-  - uid: 359
+  - uid: 360
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 360
+  - uid: 361
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
 - proto: GrilleDiagonal
   entities:
-  - uid: 361
+  - uid: 362
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,3.5
       parent: 1
-  - uid: 362
+  - uid: 363
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-0.5
       parent: 1
-  - uid: 363
+  - uid: 364
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 364
+  - uid: 365
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-11.5
       parent: 1
-  - uid: 365
+  - uid: 366
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-11.5
       parent: 1
-  - uid: 366
+  - uid: 367
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 367
+  - uid: 368
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 368
-    components:
-    - type: Transform
-      pos: 1.5,6.5
-      parent: 1
   - uid: 369
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,6.5
+      pos: 1.5,6.5
       parent: 1
   - uid: 370
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 9.5,0.5
+      pos: 7.5,6.5
       parent: 1
   - uid: 371
     components:
     - type: Transform
-      pos: 2.5,8.5
+      rot: -1.5707963267948966 rad
+      pos: 9.5,0.5
       parent: 1
   - uid: 372
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 373
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2898,13 +3016,13 @@ entities:
       parent: 1
 - proto: Gyroscope
   entities:
-  - uid: 373
+  - uid: 374
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-7.5
       parent: 1
-  - uid: 374
+  - uid: 375
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2912,28 +3030,28 @@ entities:
       parent: 1
 - proto: KitchenReagentGrinder
   entities:
-  - uid: 375
+  - uid: 376
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 1
 - proto: LockerEngineerFilled
   entities:
-  - uid: 376
+  - uid: 377
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
 - proto: LockerMedicineFilled
   entities:
-  - uid: 377
+  - uid: 378
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
 - proto: LockerWallColorChemistryFilled
   entities:
-  - uid: 378
+  - uid: 379
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2941,7 +3059,7 @@ entities:
       parent: 1
 - proto: LockerWallColorMedicalFilled
   entities:
-  - uid: 379
+  - uid: 380
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2949,7 +3067,7 @@ entities:
       parent: 1
 - proto: LockerWallEVAColorFsbFilled
   entities:
-  - uid: 380
+  - uid: 381
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2957,104 +3075,104 @@ entities:
       parent: 1
 - proto: LockerWallMaterialsFuelAmeJarFilled
   entities:
-  - uid: 381
+  - uid: 382
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
 - proto: MachineCentrifuge
   entities:
-  - uid: 382
+  - uid: 383
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
 - proto: MachineElectrolysisUnit
   entities:
-  - uid: 383
+  - uid: 384
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
 - proto: MedicalAssembler
   entities:
-  - uid: 384
+  - uid: 385
     components:
     - type: Transform
       pos: 8.5,-3.5
       parent: 1
 - proto: MedicalBag
   entities:
-  - uid: 385
+  - uid: 386
     components:
     - type: Transform
       pos: 7.65191,-1.5557239
       parent: 1
 - proto: MedicalBed
   entities:
-  - uid: 386
+  - uid: 387
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 387
+  - uid: 388
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 1
-  - uid: 388
+  - uid: 389
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
 - proto: MedicalTechFab
   entities:
-  - uid: 389
+  - uid: 390
     components:
     - type: Transform
       pos: 7.5,-0.5
       parent: 1
 - proto: MedkitBruteFilled
   entities:
-  - uid: 390
+  - uid: 391
     components:
     - type: Transform
       pos: 9.696052,-3.2031791
       parent: 1
 - proto: MedkitBurnFilled
   entities:
-  - uid: 391
+  - uid: 392
     components:
     - type: Transform
       pos: 9.696052,-3.4156792
       parent: 1
 - proto: MedkitFilled
   entities:
-  - uid: 392
+  - uid: 393
     components:
     - type: Transform
       pos: -0.46826363,-3.3098707
       parent: 1
 - proto: MedkitOxygenFilled
   entities:
-  - uid: 393
+  - uid: 394
     components:
     - type: Transform
       pos: 9.333551,-3.4906793
       parent: 1
 - proto: MedkitToxinFilled
   entities:
-  - uid: 394
+  - uid: 395
     components:
     - type: Transform
       pos: 9.321052,-3.2656791
       parent: 1
 - proto: NFHolopadShip
   entities:
-  - uid: 395
+  - uid: 570
     components:
     - type: Transform
-      pos: 3.5,6.5
+      pos: 4.5,5.5
       parent: 1
 - proto: NitrogenCanister
   entities:
@@ -3250,261 +3368,227 @@ entities:
     - type: Transform
       pos: 6.5,-5.5
       parent: 1
-- proto: SignalButton
+- proto: ShuttersNormalOpen
   entities:
   - uid: 425
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,5.5
+      pos: 4.5,8.5
       parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        451:
-        - - Pressed
-          - Toggle
-        452:
-        - - Pressed
-          - Toggle
-        455:
-        - - Pressed
-          - Toggle
-        456:
-        - - Pressed
-          - Toggle
-        453:
-        - - Pressed
-          - Toggle
-        445:
-        - - Pressed
-          - Toggle
-        443:
-        - - Pressed
-          - Toggle
-        449:
-        - - Pressed
-          - Toggle
-        450:
-        - - Pressed
-          - Toggle
-        458:
-        - - Pressed
-          - Toggle
-        457:
-        - - Pressed
-          - Toggle
-        448:
-        - - Pressed
-          - Toggle
-        447:
-        - - Pressed
-          - Toggle
-        442:
-        - - Pressed
-          - Toggle
-        444:
-        - - Pressed
-          - Toggle
-        454:
-        - - Pressed
-          - Toggle
-        446:
-        - - Pressed
-          - Toggle
-    - type: Fixtures
-      fixtures: {}
+  - uid: 426
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 427
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 428
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 429
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,7.5
+      parent: 1
 - proto: SinkWide
   entities:
-  - uid: 426
+  - uid: 430
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
-  - uid: 427
+  - uid: 431
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 1
 - proto: SMESBasic
   entities:
-  - uid: 428
+  - uid: 432
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 429
+  - uid: 433
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
 - proto: StasisBed
   entities:
-  - uid: 430
+  - uid: 434
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
 - proto: SubstationWallBasic
   entities:
-  - uid: 431
+  - uid: 435
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 432
-    components:
-    - type: Transform
-      pos: 4.5,5.5
-      parent: 1
-  - uid: 433
-    components:
-    - type: Transform
-      pos: 7.5,-1.5
-      parent: 1
-  - uid: 434
-    components:
-    - type: Transform
-      pos: 6.5,1.5
-      parent: 1
-  - uid: 435
-    components:
-    - type: Transform
-      pos: 6.5,2.5
-      parent: 1
   - uid: 436
     components:
     - type: Transform
-      pos: 2.5,0.5
+      pos: 3.5,6.5
       parent: 1
   - uid: 437
     components:
     - type: Transform
-      pos: 2.5,1.5
+      pos: 7.5,-1.5
       parent: 1
   - uid: 438
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 439
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 440
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 441
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 442
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
 - proto: TableReinforcedGlass
   entities:
-  - uid: 439
+  - uid: 443
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 440
+  - uid: 444
     components:
     - type: Transform
       pos: 9.5,-3.5
       parent: 1
 - proto: TelecomServerFilledShuttle
   entities:
-  - uid: 441
+  - uid: 445
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
 - proto: Thruster
   entities:
-  - uid: 442
+  - uid: 446
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-9.5
       parent: 1
-  - uid: 443
+  - uid: 447
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-9.5
       parent: 1
-  - uid: 444
+  - uid: 448
     components:
     - type: Transform
       pos: 10.5,-1.5
       parent: 1
-  - uid: 445
+  - uid: 449
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 446
+  - uid: 450
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-14.5
       parent: 1
-  - uid: 447
+  - uid: 451
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-10.5
       parent: 1
-  - uid: 448
+  - uid: 452
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-11.5
       parent: 1
-  - uid: 449
+  - uid: 453
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-10.5
       parent: 1
-  - uid: 450
+  - uid: 454
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-11.5
       parent: 1
-  - uid: 451
+  - uid: 455
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 452
+  - uid: 456
     components:
     - type: Transform
       pos: 7.5,5.5
       parent: 1
-  - uid: 453
+  - uid: 457
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-0.5
       parent: 1
-  - uid: 454
+  - uid: 458
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-0.5
       parent: 1
-  - uid: 455
+  - uid: 459
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 456
+  - uid: 460
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 1
 - proto: ThrusterLarge
   entities:
-  - uid: 457
+  - uid: 461
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-13.5
       parent: 1
-  - uid: 458
+  - uid: 462
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3512,472 +3596,472 @@ entities:
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 459
+  - uid: 463
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 460
+  - uid: 464
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
-  - uid: 461
+  - uid: 465
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 462
+  - uid: 466
     components:
     - type: Transform
       pos: 10.5,-3.5
       parent: 1
-  - uid: 463
+  - uid: 467
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 464
+  - uid: 468
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 465
+  - uid: 469
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 466
+  - uid: 470
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 467
+  - uid: 471
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 468
+  - uid: 472
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 469
+  - uid: 473
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 470
+  - uid: 474
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 471
+  - uid: 475
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 472
+  - uid: 476
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 473
+  - uid: 477
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 474
+  - uid: 478
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 475
+  - uid: 479
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 476
+  - uid: 480
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 477
+  - uid: 481
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 1
-  - uid: 478
+  - uid: 482
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 1
-  - uid: 479
+  - uid: 483
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 1
-  - uid: 480
+  - uid: 484
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 1
-  - uid: 481
+  - uid: 485
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 1
-  - uid: 482
+  - uid: 486
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 1
-  - uid: 483
+  - uid: 487
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 1
-  - uid: 484
+  - uid: 488
     components:
     - type: Transform
       pos: 8.5,0.5
       parent: 1
-  - uid: 485
+  - uid: 489
     components:
     - type: Transform
       pos: 8.5,-0.5
       parent: 1
-  - uid: 486
+  - uid: 490
     components:
     - type: Transform
       pos: 8.5,-1.5
       parent: 1
-  - uid: 487
+  - uid: 491
     components:
     - type: Transform
       pos: 9.5,-1.5
       parent: 1
-  - uid: 488
+  - uid: 492
     components:
     - type: Transform
       pos: 9.5,-2.5
       parent: 1
-  - uid: 489
+  - uid: 493
     components:
     - type: Transform
       pos: 9.5,-6.5
       parent: 1
-  - uid: 490
+  - uid: 494
     components:
     - type: Transform
       pos: 9.5,-8.5
       parent: 1
-  - uid: 491
+  - uid: 495
     components:
     - type: Transform
       pos: 9.5,-7.5
       parent: 1
-  - uid: 492
+  - uid: 496
     components:
     - type: Transform
       pos: 8.5,-9.5
       parent: 1
-  - uid: 493
+  - uid: 497
     components:
     - type: Transform
       pos: 7.5,-9.5
       parent: 1
-  - uid: 494
+  - uid: 498
     components:
     - type: Transform
       pos: 7.5,-10.5
       parent: 1
-  - uid: 495
+  - uid: 499
     components:
     - type: Transform
       pos: 7.5,-11.5
       parent: 1
-  - uid: 496
+  - uid: 500
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 1
-  - uid: 497
+  - uid: 501
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 498
+  - uid: 502
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 1
-  - uid: 499
+  - uid: 503
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 1
-  - uid: 500
+  - uid: 504
     components:
     - type: Transform
       pos: 3.5,-13.5
       parent: 1
-  - uid: 501
+  - uid: 505
     components:
     - type: Transform
       pos: 4.5,-13.5
       parent: 1
-  - uid: 502
+  - uid: 506
     components:
     - type: Transform
       pos: 5.5,-13.5
       parent: 1
-  - uid: 503
+  - uid: 507
     components:
     - type: Transform
       pos: 5.5,-14.5
       parent: 1
-  - uid: 504
+  - uid: 508
     components:
     - type: Transform
       pos: 0.5,-12.5
       parent: 1
-  - uid: 505
+  - uid: 509
     components:
     - type: Transform
       pos: 0.5,-13.5
       parent: 1
-  - uid: 506
+  - uid: 510
     components:
     - type: Transform
       pos: 8.5,-12.5
       parent: 1
-  - uid: 507
+  - uid: 511
     components:
     - type: Transform
       pos: 8.5,-13.5
       parent: 1
-  - uid: 508
+  - uid: 512
     components:
     - type: Transform
       pos: 3.5,-14.5
       parent: 1
-  - uid: 509
+  - uid: 513
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
-  - uid: 510
+  - uid: 514
     components:
     - type: Transform
       pos: 8.5,-8.5
       parent: 1
-  - uid: 511
+  - uid: 515
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
-  - uid: 512
+  - uid: 516
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 1
-  - uid: 513
+  - uid: 517
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 514
+  - uid: 518
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 1
-  - uid: 515
+  - uid: 519
     components:
     - type: Transform
       pos: 5.5,-11.5
       parent: 1
-  - uid: 516
+  - uid: 520
     components:
     - type: Transform
       pos: 3.5,-12.5
       parent: 1
-  - uid: 517
+  - uid: 521
     components:
     - type: Transform
       pos: 6.5,-11.5
       parent: 1
-  - uid: 518
+  - uid: 522
     components:
     - type: Transform
       pos: 3.5,-11.5
       parent: 1
-  - uid: 519
+  - uid: 523
     components:
     - type: Transform
       pos: 5.5,-12.5
       parent: 1
-  - uid: 520
+  - uid: 524
     components:
     - type: Transform
       pos: 4.5,-12.5
       parent: 1
-  - uid: 521
+  - uid: 525
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
-  - uid: 522
+  - uid: 526
     components:
     - type: Transform
       pos: 7.5,-8.5
       parent: 1
-  - uid: 523
+  - uid: 527
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 524
+  - uid: 528
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 1
-  - uid: 525
+  - uid: 529
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 526
+  - uid: 530
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 1
-  - uid: 527
+  - uid: 531
     components:
     - type: Transform
       pos: 7.5,-7.5
       parent: 1
-  - uid: 528
+  - uid: 532
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 529
+  - uid: 533
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
-  - uid: 530
+  - uid: 534
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
-  - uid: 531
+  - uid: 535
     components:
     - type: Transform
       pos: 6.5,-6.5
       parent: 1
-  - uid: 532
+  - uid: 536
     components:
     - type: Transform
       pos: 7.5,-6.5
       parent: 1
-  - uid: 533
+  - uid: 537
     components:
     - type: Transform
       pos: 10.5,-6.5
       parent: 1
-  - uid: 534
+  - uid: 538
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 1
-  - uid: 535
+  - uid: 539
     components:
     - type: Transform
       pos: 10.5,-2.5
       parent: 1
-  - uid: 536
+  - uid: 540
     components:
     - type: Transform
       pos: 7.5,0.5
       parent: 1
-  - uid: 537
+  - uid: 541
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 538
+  - uid: 542
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 539
+  - uid: 543
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 540
+  - uid: 544
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 541
+  - uid: 545
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
-  - uid: 542
+  - uid: 546
     components:
     - type: Transform
       pos: 7.5,-2.5
       parent: 1
-  - uid: 543
+  - uid: 547
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 544
+  - uid: 548
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-  - uid: 545
+  - uid: 549
     components:
     - type: Transform
       pos: 8.5,-2.5
       parent: 1
-  - uid: 546
+  - uid: 550
     components:
     - type: Transform
       pos: 6.5,0.5
       parent: 1
-  - uid: 547
+  - uid: 551
     components:
     - type: Transform
       pos: 6.5,-2.5
       parent: 1
 - proto: WallReinforcedDiagonal
   entities:
-  - uid: 548
+  - uid: 552
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-14.5
       parent: 1
-  - uid: 549
+  - uid: 553
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-14.5
       parent: 1
-  - uid: 550
+  - uid: 554
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-15.5
       parent: 1
-  - uid: 551
+  - uid: 555
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3985,7 +4069,7 @@ entities:
       parent: 1
 - proto: WallWeaponCapacitorRecharger
   entities:
-  - uid: 552
+  - uid: 556
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3993,27 +4077,27 @@ entities:
       parent: 1
 - proto: WarpPoint
   entities:
-  - uid: 553
+  - uid: 557
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
 - proto: WeaponCapacitorRecharger
   entities:
-  - uid: 554
+  - uid: 558
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
 - proto: Windoor
   entities:
-  - uid: 555
+  - uid: 559
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-6.5
       parent: 1
-  - uid: 556
+  - uid: 560
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4021,49 +4105,49 @@ entities:
       parent: 1
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 557
+  - uid: 561
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,5.5
       parent: 1
-  - uid: 558
+  - uid: 562
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,2.5
       parent: 1
-  - uid: 559
+  - uid: 563
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 1
-  - uid: 560
+  - uid: 564
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-9.5
       parent: 1
-  - uid: 561
+  - uid: 565
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-9.5
       parent: 1
-  - uid: 562
+  - uid: 566
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-1.5
       parent: 1
-  - uid: 563
+  - uid: 567
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,2.5
       parent: 1
-  - uid: 564
+  - uid: 568
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4071,7 +4155,7 @@ entities:
       parent: 1
 - proto: Wrench
   entities:
-  - uid: 565
+  - uid: 569
     components:
     - type: Transform
       pos: 0.42960453,-6.564963

--- a/Resources/Maps/_WF/Shuttles/Outlaw/veliola.yml
+++ b/Resources/Maps/_WF/Shuttles/Outlaw/veliola.yml
@@ -2356,7 +2356,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-- proto: GasMixerFlipped
+- proto: GasMixerOnFlipped
   entities:
   - uid: 294
     components:

--- a/Resources/Maps/_WF/Shuttles/Outlaw/veliola.yml
+++ b/Resources/Maps/_WF/Shuttles/Outlaw/veliola.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 267.3.0
   forkId: ""
   forkVersion: ""
-  time: 06/29/2026 08:29:54
-  entityCount: 630
+  time: 07/12/2026 05:49:13
+  entityCount: 632
 maps: []
 grids:
 - 1
@@ -1125,6 +1125,13 @@ entities:
       rot: 6.283185307179586 rad
       pos: 2.2631545,-5.7171087
       parent: 1
+- proto: BoxBeaker
+  entities:
+  - uid: 632
+    components:
+    - type: Transform
+      pos: 6.5593185,-3.5602026
+      parent: 1
 - proto: BoxFolderRedEmpty
   entities:
   - uid: 107
@@ -2137,6 +2144,16 @@ entities:
         105:
         - - device-button-3
           - Toggle
+        416:
+        - - device-button-1
+          - On
+        - - device-button-2
+          - Off
+        415:
+        - - device-button-2
+          - Off
+        - - device-button-1
+          - On
 - proto: ComputerWallmountStationRecords
   entities:
   - uid: 270
@@ -2158,6 +2175,13 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
+- proto: CrateMaterialsBasicFilled
+  entities:
+  - uid: 631
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 1
 - proto: CrateMedical
   entities:
   - uid: 272

--- a/Resources/Prototypes/_Mono/Shipyard/velios.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/velios.yml
@@ -13,7 +13,7 @@
   category: Medium
   group: Medical
   shuttlePath: /Maps/_Mono/Shuttles/velios.yml
-  guidebookPage: null
+  guidebookPage: ShipyardVelios
   class:
   - Medical
   - Chemistry

--- a/Resources/Prototypes/_WF/Guidebook/Shipyards.yml
+++ b/Resources/Prototypes/_WF/Guidebook/Shipyards.yml
@@ -126,6 +126,7 @@
   - ShipyardSpirit # FrontierShip Resources/Prototypes/_NF/Guidebook/shipyard.yml
   - ShipyardStasis # FrontierShip Resources/Prototypes/_NF/Guidebook/shipyard.yml
   - ShipyardTyne # FrontierShip Resources/Prototypes/_NF/Guidebook/shipyard.yml
+  - ShipyardVelios
   - ShipyardVitalis # FrontierShip Resources/Prototypes/_NF/Guidebook/shipyard.yml
 
 - type: guideEntry
@@ -263,7 +264,7 @@
   id: ShipyardManta
   name: guide-entry-shipyard-manta
   text: "/ServerInfo/_WF/Guidebook/Shipyard/CivShipyard/Manta.xml"
-  
+
 - type: guideEntry
   id: ShipyardMedivac
   name: guide-entry-shipyard-medivac
@@ -328,6 +329,11 @@
   id: ShipyardKobold
   name: guide-entry-shipyard-kobold
   text: "/ServerInfo/_WF/Guidebook/Shipyard/ExpedShipyard/Kobold.xml"
+
+- type: guideEntry
+  id: ShipyardVelios
+  name: guide-entry-shipyard-velios
+  text: "/ServerInfo/_WF/Guidebook/Shipyard/MedShipyard/Velios.xml"
 
 - type: guideEntry
   id: ShipyardVeliola

--- a/Resources/ServerInfo/_WF/Guidebook/Shipyard/MedShipyard/Velios.xml
+++ b/Resources/ServerInfo/_WF/Guidebook/Shipyard/MedShipyard/Velios.xml
@@ -1,7 +1,7 @@
 <Document>
-  # VELIOLA-CLASS OUTLAW MEDICAL SHUTTLE
+  # VELIOS-CLASS MEDICAL SHUTTLE
   <Box>
-    <GuideEntityEmbed Entity="ShuttleGunSvalinnMachineGun" Caption="Svalinns"/>
+    <GuideEntityEmbed Entity="CryoPod" Caption=""/>
   </Box>
 
   [color=#a4885c]Ship Size:[/color] Medium
@@ -12,17 +12,15 @@
 
   # Shuttle Brief
 
-  "Built for outlaw recovery and hit-and-run raids, the Veliola is an agile and maneuverable vessel. Add turrets to the sides, or change it how you see fit for your goal."
+  "Formerly a combat vessel, the Velios has been refitted to be an agile patient recovery ship."
 
   # Ship Functions
   - The shuttle console is pre-wired to the entire ship.
   - Buttons [color=#a4885c]1[/color] and [color=#a4885c]2[/color] toggle the engines and gyroscopes on and off respectively.
-  - Button [color=#a4885c]3[/color] controls the cockpit blast doors.
-  - Buttons [color=#a4885c]7[/color] and [color=#a4885c]8[/color] toggle the Svalinn gun turrets on and off.
+  - Button [color=#a4885c]3[/color] controls the cockpit shutters.
 
-  # Tips on running the Veliola
-  - To conserve AME fuel, consider running it enough to charge the SMES, then turning it off unless in combat.
-  - The bridge has two side doors and rechargers with spare cells for the turrets. Use them to your advantage.
+  # Tips on running the Velios
+  - To conserve AME fuel, consider running it enough to charge the SMES, then turning it off.
 
   # Piloting
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a guidebook entry for the Velios, adds missing beaker box and basic material cache to the engineering room for both ships, removes the cockpit side button in favor of linking thrusters and gyroscopes to the shuttle console directly, adds shutters to the velios cockpit.

## Why / Balance
Parity between both ships is good, also I was dumb and deleted supplies which should've been in these ships roundstart.

## Technical details
Slop.

## How to test
Buy the ships.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Oh, here's the changed velios cockpit for reference. (Closer to the Veliola's)
<img width="599" height="534" alt="image" src="https://github.com/user-attachments/assets/f2771fd2-14e4-4aa5-a796-a37c64522684" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Guidebook entry for the Velios, detailing similar controls to the Veliola's.
- tweak: Both the Velios and the Veliola now spawn with roundstart basic supplies in their engineering room, and beakers, which were missing before.
