### PR TITLE
[CGP/Balance] Nerfing of combat and jugsuit

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -284,7 +284,7 @@
         Caustic: 0.6
   - type: ClothingSpeedModifier
     walkModifier: 0.85
-    sprintModifier: 0.75
+    sprintModifier: 0.80 #Wayfarer: 0.75<0.80
 
 #Security Command Hardsuit
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -272,7 +272,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.4
   - type: StaminaResistance # Wayfarer
-    damageCoefficient: 0.75
+    damageCoefficient: 0.80
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -244,12 +244,12 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.2
-        Slash: 0.2
-        Piercing: 0.2
-        Heat: 0.2
-        Radiation: 0.2
-        Caustic: 0.2
+        Blunt: 0.3 # Wayfarer: 0.2<0.3
+        Slash: 0.3 # Wayfarer: 0.2<0.3
+        Piercing: 0.3 # Wayfarer: 0.2<0.3
+        Heat: 0.3 # Wayfarer: 0.2<0.3
+        Radiation: 0.3 # Wayfarer: 0.2<0.3
+        Caustic: 0.3 # Wayfarer: 0.2<0.3
   - type: ClothingSpeedModifier
     walkModifier: 0.70
     sprintModifier: 0.65
@@ -283,8 +283,8 @@
         Radiation: 0.4
         Caustic: 0.6
   - type: ClothingSpeedModifier
-    walkModifier: 0.90 # Wayfarer: 0.85<0.90
-    sprintModifier: 0.85 # Wayfarer: 0.75<0.85
+    walkModifier: 0.85
+    sprintModifier: 0.75
 
 #Security Command Hardsuit
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -14,9 +14,9 @@
         Heat: 3
         Structural: 30
   - type: StaminaDamageOnHit
-    damage: 17 # 6 hits
+    damage: 22 # Wayfarer: 17<22 5 hits
   - type: StaminaDamageOnCollide
-    damage: 17 # 6 hits
+    damage: 22 # Wayfarer: 17<22 5 hits
 
 - type: entity
   id: NFEnergyPickaxe


### PR DESCRIPTION
## About the PR
Yml changes to CGP.
Its awesome to see cgp doing so well in numbers, but I do feel we need to balance out a few things.
changes jugsuit to an overall 70% and makes combat a 20 slowdown 20 stam res.
E sword more stam damage 22 5 hit break point with a bit extra

## Why / Balance
Combat suits are printable red suits. Yes I know, outlaws shit em out of their ass, but most newbie outlaws don't know how to get those and at least redsuits have some risk involved of going out or wasting all your dc. I think cgp was doing fine with slow combats. 
Jugsuit was a bit too strong and with ipcs negating most of its counters, some damage numbers need to go down sadly for now a 70% damage res is go. Jugsuit is not really viable as solo cgp and its mostly used to either go into extremely prolongued eva fights or bring the hammer down.

## Technical details
yml slop

## How to test
spawn cgp outfits, see their new stats

## Media

## Requirements
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)

## Breaking changes
none
:cl:
- tweak: Jugsuit down in res, combat suit back to old speed and energy sword for cgp buffed.
