### PR TITLE
[CGP/Balance] Increased Fuc payout of pods

### DIFF
--- a/Content.Server/Forensics/Systems/ForensicScannerSystem.cs
+++ b/Content.Server/Forensics/Systems/ForensicScannerSystem.cs
@@ -62,13 +62,13 @@ namespace Content.Server.Forensics
         private SoundSpecifier _confirmSound = new SoundPathSpecifier("/Audio/Effects/Cargo/ping.ogg");
 
         private const int ActiveUnusedDeadDropSpesoReward = 20000;
-        private const float ActiveUnusedDeadDropFUCReward = 2.0f;
+        private const float ActiveUnusedDeadDropFUCReward = 4.0f; //Wayfarer 2.0<4.0
         private const int ActiveUsedDeadDropSpesoReward = 10000;
         private const float ActiveUsedDeadDropFUCReward = 1.0f;
         private const int InactiveUsedDeadDropSpesoReward = 5000;
         private const float InactiveUsedDeadDropFUCReward = 0.5f;
         private const int DropPodSpesoReward = 10000;
-        private const float DropPodFUCReward = 1.0f;
+        private const float DropPodFUCReward = 2.0f;  // Wayfarer: 1.0<2.0
         // End Frontier: payout constants
 
         private static readonly ProtoId<TagPrototype> DNASolutionScannableTag = "DNASolutionScannable";


### PR DESCRIPTION
## About the PR
Increased payout from pods

## Why / Balance
Fuc payouts from the pods were slightly miserable and considering cgp can't touch the inside of them, I think its a valid buff to try higher ZC for this and to encourage counter smuggling

## Technical details
Changes in content.server to the forensics section, commented under wayfarer

## How to test
start an ingame smuggling pod drop, spawn it, then tp to it with a forensic scanner, can it, 2 zc, good

## Media

## Requirements
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)

## Breaking changes
Changes the following floats in the forensicscannersystem
        private const float ActiveUnusedDeadDropFUCReward = 4.0f; //Wayfarer 2.0<4.0
        private const float DropPodFUCReward = 2.0f;  // Wayfarer: 1.0<2.0

**Changelog**
- tweak: ZC payout from pods and notes increased by 2 and 4 respectively.
