### PR TITLE
made Cyborgs do surgery faster

### DIFF
--- a/Content.Shared/Medical/Healing/HealingSystem.cs
+++ b/Content.Shared/Medical/Healing/HealingSystem.cs
@@ -20,7 +20,8 @@ using Content.Shared.Tag; // Wayfarer
 using Robust.Shared.Serialization.TypeSerializers.Implementations; // Wayfarer
 using Content.Shared.Inventory; // Wayfarer
 using Content.Shared.Buckle; // Wayfarer
-using Content.Shared.Buckle.Components; // Wayfarer
+using Content.Shared.Buckle.Components;
+using Content.Shared.Silicons.Borgs.Components; // Wayfarer
 
 namespace Content.Shared.Medical.Healing;
 
@@ -330,6 +331,16 @@ public sealed partial class HealingSystem : EntitySystem // Wayfarer: Added Part
                         surgicalEnvironmentPoints += 2;
                     }
                 }
+            }
+        }
+        //Cyborg - as borgs cant wear clothes, they get seperate bonuses to make medical cyborgs viable. 
+
+        if (TryComp<BorgSwitchableTypeComponent>(user, out var chassis) && chassis is not null)
+        {
+            surgicalEnvironmentPoints += 2; //any cyborg is as good as a humanoid with non-sterile gloves and a mask
+            if (chassis.SelectedBorgType == "medical")
+            {
+                surgicalEnvironmentPoints += 3; //medical cyborgs are as good as a humanoid with full surgical gear on. 
             }
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Cyborgs gain a bonus to surgery speed, compensating for not being able to wear clothes.
All cyborgs are equivalent to a player in generic gloves and mask, except for Medical borgs which are equivalent to a full surgeon

## Why / Balance
Allows Medical Borg to be a viable playstyle

## Technical details
One block of if statements.

## How to test
Spawn a borg, try surgery, note speed is 18s
Spawn a mediborg, try surgery, note speed is 10s
(I have already tested this)

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- tweak: Cyborgs, especially medical cyborgs, get bonuses to surgery speed.

