### PR TITLE
Senior Peacekeeper - Proper Access

### DIFF
--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/senior_officer.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/senior_officer.yml
@@ -16,7 +16,7 @@
   access:
   - Sergeant
   accessGroups:
-  - GeneralNfsdAccess
+  - CGPCommand #Wayfarer: GeneralNfsdAccess<CGPCommand
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant, NFSDTrackingImplant ]

--- a/Resources/Prototypes/_WF/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_WF/Loadouts/role_loadouts.yml
@@ -364,7 +364,7 @@
   - NfsdFace
   - NfsdGlasses
   - NfsdBelt
-  - NfsdEarsMaster
+  - SheriffEars
   - NfsdBoxSurvival
   - SeniorPeacekeeperPDA
   - WFWallet


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Sr Keeper is a staff training role, yet it does not have access to command, locked areas, or funds to pay those recruits.
They could not even open slots for the people they are intended to be training. Why????
This PR corrects this. It does not suddenly grant them more authority.

Anyone who is a problem with this should just be role banned moving forwards in the future.

## Why / Balance
Heavily discussed on discord and made with headmin approval.
Allows them to actually do their damn jobs.

## Technical details
Yaml - Two lines

## How to test
Sr Keeper, do your job.

## Media
<img width="1672" height="1105" alt="image" src="https://github.com/user-attachments/assets/f93dcbfc-3ca3-4b50-bf1d-a0eac404c981" />
<img width="1088" height="732" alt="image" src="https://github.com/user-attachments/assets/61046699-6fde-40c4-84e1-f3cf4d4dd616" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- add: Added higher access to Senior Peacekeeper, same as MAA.
