### PR TITLE
Decouple lantern turn on and flash use

### DIFF
--- a/Content.Shared/Flash/Components/FlashComponent.cs
+++ b/Content.Shared/Flash/Components/FlashComponent.cs
@@ -23,6 +23,12 @@ public sealed partial class FlashComponent : Component
     public bool FlashOnMelee = true;
 
     /// <summary>
+    /// Flash the area around the entity when toggled?
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool FlashOnToggle = true;
+
+    /// <summary>
     /// Time the Flash will be visually flashing after use.
     /// For the actual interaction delay use UseDelayComponent.
     /// These two times should be the same.

--- a/Content.Shared/Flash/Components/FlashComponent.cs
+++ b/Content.Shared/Flash/Components/FlashComponent.cs
@@ -22,11 +22,13 @@ public sealed partial class FlashComponent : Component
     [DataField, AutoNetworkedField]
     public bool FlashOnMelee = true;
 
+    /// Wayfarer Start
     /// <summary>
     /// Flash the area around the entity when toggled?
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool FlashOnToggle = true;
+    /// Wayfarer End
 
     /// <summary>
     /// Time the Flash will be visually flashing after use.

--- a/Content.Shared/Flash/SharedFlashSystem.cs
+++ b/Content.Shared/Flash/SharedFlashSystem.cs
@@ -96,7 +96,7 @@ public abstract class SharedFlashSystem : EntitySystem
     // TODO: This is awful and all the different components for toggleable lights need to be unified and changed to use Itemtoggle
     private void OnLightToggle(Entity<FlashComponent> ent, ref LightToggleEvent args)
     {
-        if (!args.IsOn || !UseFlash(ent, null))
+        if (!ent.Comp.FlashOnToggle || !args.IsOn || !UseFlash(ent, null))
             return;
 
         FlashArea(ent.Owner, null, ent.Comp.Range, ent.Comp.AoeFlashDuration, ent.Comp.SlowTo, true, ent.Comp.Probability);

--- a/Content.Shared/Flash/SharedFlashSystem.cs
+++ b/Content.Shared/Flash/SharedFlashSystem.cs
@@ -96,7 +96,7 @@ public abstract class SharedFlashSystem : EntitySystem
     // TODO: This is awful and all the different components for toggleable lights need to be unified and changed to use Itemtoggle
     private void OnLightToggle(Entity<FlashComponent> ent, ref LightToggleEvent args)
     {
-        if (!ent.Comp.FlashOnToggle || !args.IsOn || !UseFlash(ent, null))
+        if (!ent.Comp.FlashOnToggle || !args.IsOn || !UseFlash(ent, null)) ///Wayfarer add !ent.Comp.FlashOnToggle
             return;
 
         FlashArea(ent.Owner, null, ent.Comp.Range, ent.Comp.AoeFlashDuration, ent.Comp.SlowTo, true, ent.Comp.Probability);

--- a/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
@@ -90,8 +90,10 @@
       radius: 5
       energy: 10
     - type: Flash
-      flashOnMelee: false
-      flashOnUse: false
+      flashOnToggle: false
+    - type: UseDelay
+      delay: 4
+    - type: UseDelayOnMeleeHit
     - type: LimitedCharges
       maxCharges: 15
     - type: MeleeWeapon

--- a/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
@@ -90,10 +90,14 @@
       radius: 5
       energy: 10
     - type: Flash
+      # Wayfarer Start
+      # flashOnUse: false
+      # flashOnMelee: false
       flashOnToggle: false
     - type: UseDelay
       delay: 4
     - type: UseDelayOnMeleeHit
+      # Wayfarer End
     - type: LimitedCharges
       maxCharges: 15
     - type: MeleeWeapon


### PR DESCRIPTION
Separates the Super-bright lantern turning on, and the lantern being used into two different parts.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Fixes issue [#654](https://github.com/project-wayfarer/wayfarer-14/issues/654) by separating using the lantern and toggling the light.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
You can now flash the lantern independently from turning it on
## Technical details
<!-- Summary of code changes for easier review. -->
Added a new ent component, "FlashOnToggle" to FlashComponent.cs. Added that condition to OnLightToggle in SharedFlashSystem.cs, then commented out "FlashOnUse: false" in the lantern, to allow manual activation of it. 
## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Press E or Z on lantern, this will cause it to flash.
Right click and toggle the light. It'll turn on without causing a flash.
Melee a urist with the light, they'll be stunned by it.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- fix: Super-bright lantern flashing every time it's turned on, rather than being a manual flash.

