### PR TITLE
[Outlaw] Drives now give datachits

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/treasure.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/treasure.yml
@@ -332,6 +332,8 @@
   - type: StaticPrice
     price: 750
   - type: NFTreasure
+  - type: PirateBountyItem # Wayfarer
+    id: EncryptedData # Wayfarer
 
 - type: entity
   parent: BaseItem
@@ -356,6 +358,8 @@
   - type: StaticPrice
     price: 900
   - type: NFTreasure
+  - type: PirateBountyItem # Wayfarer
+    id: EncryptedData # Wayfarer
 
 - type: entity
   parent: BaseItem


### PR DESCRIPTION
## About the PR
Makes ssd drives and network boards give dc like the others

## Why / Balance
they came from NF upstream and we never updated these drives

## Technical details
yml slop

## How to test
spawn an ssd
cash it out for a dc

## Media

## Requirements
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)

## Breaking changes
none

**Changelog**
:cl:
- add: NF added loot involving disks has been updated to give DC
