### PR TITLE
[Balance] Makes bluespace bags smaller

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -354,7 +354,7 @@
   - type: Storage
     maxItemSize: Huge
     grid:
-    - 0,0,7,7 # Frontier: Was 0,0,19,9
+    - 0,0,7,5 # Frontier: Was 0,0,19,9 Wayfarer: 0,0,7,7 < 0,0,7,5
   - type: WFBluespaceQuirkMessages # WF
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -262,7 +262,7 @@
   - type: Storage
     maxItemSize: Huge
     grid:
-    - 0,0,7,7 # Frontier: Was 0,0,19,9
+    - 0,0,7,5 # Frontier: Was 0,0,19,9 Wayfarer: 0,0,7,7 < 0,0,7,5
   - type: ClothingSpeedModifier
     sprintModifier: 1 # makes its stats identical to other variants of bag of holding
   - type: HeldSpeedModifier

--- a/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
@@ -192,7 +192,7 @@
   - type: Storage
     maxItemSize: Huge
     grid:
-    - 0,0,7,7 # Frontier: Was 0,0,19,9
+    - 0,0,7,5 # Frontier: Was 0,0,19,9 Wayfarer: 0,0,7,7 < 0,0,7,5
   - type: Clothing # Frontier
     sprite: _NF/Clothing/Back/Satchels/holding.rsi # Frontier
     clothingVisuals: # Frontier


### PR DESCRIPTION
## About the PR
Makes bluespace bags slightly smaller

## Why / Balance
People were carrying whole nukie squad worth of gear in their bags. This should keep them more in line with other bags while still being a straight update. (one row bigger than duffels with no slowdown and 2 rows bigger than regular bags)

## Technical details
yml slop

## How to test
spawn the bags of holding, see they are smaller

## Media

## Requirements
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)

## Breaking changes
yml slop

**Changelog**
:cl:
- tweak: Made bluespace bags 2 rows smaller.
