### PR TITLE
Crew Monitor Timeout Logic Fix

### DIFF
--- a/Content.Server/Medical/CrewMonitoring/CrewMonitoringServerSystem.cs
+++ b/Content.Server/Medical/CrewMonitoring/CrewMonitoringServerSystem.cs
@@ -79,13 +79,31 @@ public sealed class CrewMonitoringServerSystem : EntitySystem
     {
         if (!Resolve(uid, ref component))
             return;
-
+        /*  // Wayfarer: Commented this in favor of the logic below.
+            // This seems to be causing an exception when a sensor needs to be removed, because it's removing it from the loop while it is running?
+            // Instead, we collect keys and remove after the loop. Should do the trick.
         foreach (var (address, sensor) in component.SensorStatus)
         {
             var dif = _gameTiming.CurTime - sensor.Timestamp;
             if (dif.Seconds > component.SensorTimeout)
                 component.SensorStatus.Remove(address);
         }
+        */
+        // Wayfarer Start
+        var toRemove = new List<string>();
+        var now = _gameTiming.CurTime;
+
+        foreach (var (address, sensor) in component.SensorStatus)
+        {
+            if ((now - sensor.Timestamp).TotalSeconds > component.SensorTimeout)
+                toRemove.Add(address);
+        }
+
+        foreach (var address in toRemove)
+        {
+            component.SensorStatus.Remove(address);
+        }
+        // End Wayfarer
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes (hopefully) an issue involving crew monitoring update logic.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Because some players sometimes being unable to change their sensors is likely bad.

## Technical details
Earlier today, Carrie and I noticed that sometimes players can't seem to disable their sensors, I think it is due to an exception that seems to be triggered when sensors are disabled in a highly populated list, due to a dictionary being changed while a loop itself is running.

Instead, now we collect the keys to be removed and remove them after the loop. This should, in theory, mitigate this.

**This has only been tested minimally in my local environment, and seemed to not have any issues. Guess the best way to test this is on live, though.**

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No player-facing changes
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
