### PR TITLE
Avali Thirst-Quenching Ammonia

### DIFF
--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -227,6 +227,20 @@
           types:
             Caustic: 1
     # Wayfarer start
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 4 # same as water
+        conditions:
+        - !type:OrganType
+          type: Avali
+          shouldHave: true
+      - !type:SatiateThirst
+        factor: 1 # same as welding fuel
+        conditions:
+        - !type:OrganType
+          type: Vox
+          shouldHave: true
     Medicine:
       effects:
       - !type:HealthChange

--- a/Resources/Prototypes/Reagents/cleaning.yml
+++ b/Resources/Prototypes/Reagents/cleaning.yml
@@ -37,6 +37,36 @@
   tileReactions:
     - !type:CleanTileReaction {}
     - !type:CleanDecalsReaction {}
+  # Wayfarer start
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 4 # same as water / ammonia for avali
+        conditions:
+        - !type:OrganType
+          type: Avali
+          shouldHave: true
+      - !type:SatiateThirst
+        factor: 2.5 # average of ammonia and water for vox
+        conditions:
+        - !type:OrganType
+          type: Vox
+          shouldHave: true
+    Poison:
+      effects:
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Vox
+          shouldHave: false
+        - !type:OrganType
+          type: Avali
+          shouldHave: false
+        damage:
+          types:
+            Caustic: 0.5 # half as much as raw ammonia
+  # End Wayfarer
 
 - type: reagent
   id: SoapReagent


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I made it so that Avali (and Vox) can quench their thirst by drinking Ammonia (and Space Cleaner).

While I was at it, I made Space Cleaner deal damage to non-Avali/Vox, at half the rate of pure Ammonia.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Because Avali lore has oceans of ammonia on their homeworld, their blood is made of it, and I think it would be cool to carry it around as a preferred drink!

Space cleaner was included because it's inevitable that the ammonia would mix with water in such circumstances, and that reaction shouldn't reduce the thirst-quenching properties.

I let Vox also quench thirst with ammonia (at a lesser rate) so they could join in on the fun. (Yes, this means they can drink their own waste product of exhalation. That feels very Vox to me.)

## Technical details
<!-- Summary of code changes for easier review. -->
Just some .yml adjustment

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Be a thirsty Avali, drink Ammonia.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Avali (and Vox to a lesser degree) now can quench their thirst by drinking Ammonia or Space Cleaner!
- tweak: Drinking Space Cleaner now deals damage to non-Avali or Vox.
