### PR TITLE
Contra rating adjustments

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -69,7 +69,7 @@
   abstract: true # Frontier: use NF variant
   name: L6 SAW
   id: WeaponLightMachineGunL6
-  parent: [BaseWeaponLightMachineGun, BaseMilitaryContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband # Wayfarer: BaseC3SyndicateContraband<BaseMilitaryContraband
+  parent: [BaseWeaponLightMachineGun, BaseBMContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband # Wayfarer: BaseC3SyndicateContraband<BaseMilitaryContraband<BaseBMContraband.
   description: Developed by Waffle Corp, the L6 Squad Automatic Weapon is a deadly light machine gun often used by the Gorlex Marauders. Although bulky and cumbersome, its heavy barrel and high ammo capacity make it perfect for suppressing combatants with a hail of bullets. Feeds from .30 ammo belts.
   components:
   - type: Sprite
@@ -91,7 +91,7 @@
   abstract: true # Frontier: use NF variant
   name: L6C ROW
   id: WeaponLightMachineGunL6C
-  parent: [BaseItem, BaseMilitaryContraband] # Frontier: added BaseC3SyndicateContraband # Wayfarer: BaseC3SyndicateContraband<BaseMilitaryContraband
+  parent: [BaseItem, BaseBMContraband] # Frontier: added BaseC3SyndicateContraband # Wayfarer: BaseC3SyndicateContraband<BaseMilitaryContraband
   description: A L6 SAW for use by cyborgs. Creates .30 rifle ammo on the fly from an internal ammo fabricator, which slowly self-charges. An illegal firearm often used by Syndicate agents.
   components:
     - type: Gun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -69,7 +69,7 @@
   abstract: true # Frontier: use NF variant
   name: L6 SAW
   id: WeaponLightMachineGunL6
-  parent: [BaseWeaponLightMachineGun, BaseBMContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband # Wayfarer: BaseC3SyndicateContraband<BaseMilitaryContraband<BaseBMContraband.
+  parent: [BaseWeaponLightMachineGun, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
   description: Developed by Waffle Corp, the L6 Squad Automatic Weapon is a deadly light machine gun often used by the Gorlex Marauders. Although bulky and cumbersome, its heavy barrel and high ammo capacity make it perfect for suppressing combatants with a hail of bullets. Feeds from .30 ammo belts.
   components:
   - type: Sprite
@@ -91,7 +91,7 @@
   abstract: true # Frontier: use NF variant
   name: L6C ROW
   id: WeaponLightMachineGunL6C
-  parent: [BaseItem, BaseBMContraband] # Frontier: added BaseC3SyndicateContraband # Wayfarer: BaseC3SyndicateContraband<BaseMilitaryContraband
+  parent: [BaseItem, BaseC3SyndicateContraband] # Frontier: added BaseC3SyndicateContraband
   description: A L6 SAW for use by cyborgs. Creates .30 rifle ammo on the fly from an internal ammo fabricator, which slowly self-charges. An illegal firearm often used by Syndicate agents.
   components:
     - type: Gun

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/LMGs/base_lmg.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/LMGs/base_lmg.yml
@@ -42,7 +42,7 @@
 #region manufacturer
 - type: entity
   abstract: true
-  parent: [ BaseBMContraband, NFBaseWeaponFrameLightMachineGun ] # Wayfarer: BaseC3SyndicateContraband<BaseMilitaryContraband
+  parent: [ BaseBMContraband, NFBaseWeaponFrameLightMachineGun ] # Wayfarer: BaseC3SyndicateContraband<BaseBMContraband
   id: NFBaseWeaponFrameLightMachineGunGorlex
   components:
   - type: Gun

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/LMGs/base_lmg.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/LMGs/base_lmg.yml
@@ -42,7 +42,7 @@
 #region manufacturer
 - type: entity
   abstract: true
-  parent: [ BaseMilitaryContraband, NFBaseWeaponFrameLightMachineGun ] # Wayfarer: BaseC3SyndicateContraband<BaseMilitaryContraband
+  parent: [ BaseBMContraband, NFBaseWeaponFrameLightMachineGun ] # Wayfarer: BaseC3SyndicateContraband<BaseMilitaryContraband
   id: NFBaseWeaponFrameLightMachineGunGorlex
   components:
   - type: Gun

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -18,7 +18,7 @@
 
 - type: entity
   id: NFWeaponLightMachineGunL6C
-  parent: [ NFBaseWeaponFrameLightMachineGunGorlex, baseBMContraband ]
+  parent: [ NFBaseWeaponFrameLightMachineGunGorlex, BaseBMContraband ]
   name: cyborg GSW LMG-6
   description: |-
     A GSW LMG-6 for use by cyborgs. Creates rifle ammo on the fly from an internal ammo fabricator, which slowly self-charges. An illegal firearm often used by Syndicate agents.

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -2,7 +2,7 @@
 #region WizDen
 - type: entity
   id: NFWeaponLightMachineGunL6
-  parent: [ NFBaseWeaponLightMachineGunChamber20, NFBaseWeaponFrameLightMachineGunGorlex ]
+  parent: [ NFBaseWeaponLightMachineGunChamber20, NFBaseWeaponFrameLightMachineGunGorlex, BaseBMContraband ]
   name: GSW LMG-6
   description: |-
     A rather traditionally made LMG with a pleasantly lacquered wooden pistol grip. An illegal firearm often used by Syndicate agents.
@@ -18,7 +18,7 @@
 
 - type: entity
   id: NFWeaponLightMachineGunL6C
-  parent: [ NFBaseWeaponFrameLightMachineGunGorlex ]
+  parent: [ NFBaseWeaponFrameLightMachineGunGorlex, baseBMContraband ]
   name: cyborg GSW LMG-6
   description: |-
     A GSW LMG-6 for use by cyborgs. Creates rifle ammo on the fly from an internal ammo fabricator, which slowly self-charges. An illegal firearm often used by Syndicate agents.

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -2,7 +2,7 @@
 #region WizDen
 - type: entity
   id: NFWeaponLightMachineGunL6
-  parent: [ NFBaseWeaponLightMachineGunChamber20, NFBaseWeaponFrameLightMachineGunGorlex, BaseBMContraband ]
+  parent: [ NFBaseWeaponLightMachineGunChamber20, NFBaseWeaponFrameLightMachineGunGorlex ]
   name: GSW LMG-6
   description: |-
     A rather traditionally made LMG with a pleasantly lacquered wooden pistol grip. An illegal firearm often used by Syndicate agents.
@@ -18,7 +18,7 @@
 
 - type: entity
   id: NFWeaponLightMachineGunL6C
-  parent: [ NFBaseWeaponFrameLightMachineGunGorlex, BaseBMContraband ]
+  parent: [ NFBaseWeaponFrameLightMachineGunGorlex ]
   name: cyborg GSW LMG-6
   description: |-
     A GSW LMG-6 for use by cyborgs. Creates rifle ammo on the fly from an internal ammo fabricator, which slowly self-charges. An illegal firearm often used by Syndicate agents.


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Revert's Verse's change to L6 contra rating.

## Why / Balance
Undiscussed change. It's a light machine gun. Fits server definition of C3 contraband, not C2.

## Technical details
BaseMilitaryGradeContraband becomes BaseBMContraband.

## How to test
Spawn L6. Inspect it.

## Media
<img width="887" height="205" alt="image_2026-08-07_185456278" src="https://github.com/user-attachments/assets/80ef9533-7274-4c38-adda-a7c26e1a6fe0" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- tweak: Made L6 back into C3 contra rating.


