### PR TITLE
Inactive ships improvements

### DIFF
--- a/Content.Server/_CS/ShuttleCrewStatus/ShuttleCrewStatusComponent.cs
+++ b/Content.Server/_CS/ShuttleCrewStatus/ShuttleCrewStatusComponent.cs
@@ -26,4 +26,20 @@ public sealed partial class ShuttleCrewStatusComponent : Component
     /// </summary>
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan NextCheck = TimeSpan.Zero;
+
+    /// <summary>
+    /// The time the grid was first observed to have no active (non-ghost) players aboard,
+    /// with no active players aboard since. Null while the grid is occupied.
+    /// Used to require a sustained empty period before marking the shuttle inactive.
+    /// </summary>
+    [DataField]
+    public TimeSpan? EmptySince;
+
+    /// <summary>
+    /// The time the grid was first observed to have an active (non-ghost) player aboard,
+    /// with an active player aboard continuously since. Null while the grid is empty.
+    /// Used to require a sustained occupied period before marking the shuttle active.
+    /// </summary>
+    [DataField]
+    public TimeSpan? OccupiedSince;
 }

--- a/Content.Server/_CS/ShuttleCrewStatus/ShuttleCrewStatusSystem.cs
+++ b/Content.Server/_CS/ShuttleCrewStatus/ShuttleCrewStatusSystem.cs
@@ -17,6 +17,9 @@ namespace Content.Server._Coyote.ShuttleCrewStatus;
 /// System that periodically checks player-owned shuttles for active crew and updates IFF label colors accordingly.
 /// Only applies to shuttles with the PlayerShuttle flag set (excludes asteroids, wrecks, and other non-player grids).
 /// Shuttles with no crew or only disconnected crew show a gray label, while shuttles with active crew show normal white labels.
+/// A shuttle only becomes active after a player has been aboard continuously for <see cref="_activateDelay"/>,
+/// and only becomes inactive after being continuously empty for <see cref="_deactivateDelay"/>, to prevent
+/// players from toggling a shuttle's visibility for combat advantage by briefly entering/leaving.
 /// </summary>
 public sealed class ShuttleCrewStatusSystem : EntitySystem
 {
@@ -29,13 +32,25 @@ public sealed class ShuttleCrewStatusSystem : EntitySystem
     /// How often to check crew status on shuttles. Default: 3 minutes.
     /// Easily adjustable here for different update frequencies.
     /// </summary>
-    // private readonly TimeSpan _checkInterval = TimeSpawan.FromMinutes(3);
+    // private readonly TimeSpan _checkInterval = TimeSpan.FromMinutes(3);
     private readonly TimeSpan _checkInterval = TimeSpan.FromSeconds(10);
 
     /// <summary>
     /// The color to use when a shuttle has no active crew.
     /// </summary>
     private readonly Color _inactiveCrewColor = Color.Gray;
+
+    /// <summary>
+    /// How long a shuttle must be continuously empty of active crew before it's marked inactive.
+    /// Prevents players from briefly leaving to "cloak" a ship mid-combat.
+    /// </summary>
+    private readonly TimeSpan _deactivateDelay = TimeSpan.FromMinutes(15);
+
+    /// <summary>
+    /// How long a shuttle must have an active crew member aboard, continuously, before it's marked active.
+    /// Prevents a brief boarding from instantly revealing/using an otherwise-inactive shuttle.
+    /// </summary>
+    private readonly TimeSpan _activateDelay = TimeSpan.FromMinutes(5);
 
     public override void Initialize()
     {
@@ -88,8 +103,36 @@ public sealed class ShuttleCrewStatusSystem : EntitySystem
             // Schedule next check
             crewStatus.NextCheck = currentTime + _checkInterval;
 
-            // Check if there are any active players on this grid
-            var hasActiveCrew = HasActivePlayersOnGrid(uid, xform);
+            // Check if there are any active players on this grid right now
+            var occupiedNow = HasActivePlayersOnGrid(uid, xform);
+
+            // Track how long the grid has been continuously occupied/empty
+            if (occupiedNow)
+            {
+                crewStatus.EmptySince = null;
+                crewStatus.OccupiedSince ??= currentTime;
+            }
+            else
+            {
+                crewStatus.OccupiedSince = null;
+                crewStatus.EmptySince ??= currentTime;
+            }
+
+            // Only flip crew status once the new state has been sustained long enough.
+            // This stops players from ducking in/out of a shuttle to toggle its IFF visibility for combat purposes.
+            var hasActiveCrew = crewStatus.HasActiveCrew;
+            if (!crewStatus.HasActiveCrew
+                && crewStatus.OccupiedSince is { } occupiedSince
+                && currentTime - occupiedSince >= _activateDelay)
+            {
+                hasActiveCrew = true;
+            }
+            else if (crewStatus.HasActiveCrew
+                && crewStatus.EmptySince is { } emptySince
+                && currentTime - emptySince >= _deactivateDelay)
+            {
+                hasActiveCrew = false;
+            }
 
             // Only update IFF if the crew status changed
             if (hasActiveCrew != crewStatus.HasActiveCrew)

--- a/Content.Server/_CS/ShuttleCrewStatus/ShuttleCrewStatusSystem.cs
+++ b/Content.Server/_CS/ShuttleCrewStatus/ShuttleCrewStatusSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Systems;
 using Content.Server.Station.Components; // Wayfarer
 using Content.Shared.GameTicking;
+using Content.Shared.Ghost;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Shuttles.Systems;
 using Content.Shared.Station.Components; // Wayfarer
@@ -150,6 +151,10 @@ public sealed class ShuttleCrewStatusSystem : EntitySystem
 
             // Check if the player has an attached entity
             if (session.AttachedEntity is not { } playerEntity)
+                continue;
+
+            // Ghosts don't count as active crew
+            if (HasComp<GhostComponent>(playerEntity))
                 continue;
 
             // Check if the player entity still exists


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changes inactive ship behavior. Ghosts will no longer trip a ship to be active. Also changes the time needed of occupancy for ships to toggle between active/inactive and vice versa.

Closes #1371

## Media
[Screencast_20260809_162724.webm](https://github.com/user-attachments/assets/47d434ac-72e0-4a58-b658-4c8e3e58e5e0)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Changed ghosts triggering shuttles to active
- tweak: Changed time needed to toggle ships from active/inactive/active.
