### PR TITLE
Admin PDA blip defaults off

### DIFF
--- a/Content.Server/_CS/BlipCartridge/BlipCartridgeSystem.cs
+++ b/Content.Server/_CS/BlipCartridge/BlipCartridgeSystem.cs
@@ -272,7 +272,14 @@ public sealed class BlipCartridgeSystem : EntitySystem
         // a few settings: Toggle the blip, change the preset, change the color, change the shape, change the scale
         // lets fucking do it
         var blipData = ent.Comp;
-        var radBlip = EnsureComp<RadarBlipComponent>(ent.Owner);
+        // Wayfarer: seed a newly-created blip's Enabled from the cartridge's own default instead of
+        // RadarBlipComponent's hardcoded true, so PDAs like NFAdminPDA that set enabled: false stay off
+        // the first time their verbs are checked.
+        if (!TryComp<RadarBlipComponent>(ent.Owner, out var radBlip))
+        {
+            radBlip = EnsureComp<RadarBlipComponent>(ent.Owner);
+            radBlip.Enabled = blipData.Enabled; // Wayfarer
+        }
         // the toggle blip verb
         var toggleBlipVerb = new Verb()
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Admin PDA will not default its blip on

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
_Changelog not needed_
