### PR TITLE
Issue #1419 Bug fix where fooddoughtortillaflat had 15 nutri instead of 5.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
@@ -443,6 +443,13 @@
   - type: Construction
     graph: Tortilla
     node: flat
+  - type: SolutionContainerManager # WF14 added nutri and set to 5 to fix nutri stats per issue #1419.
+    solutions:
+      food:
+        maxVol: 18
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5
 
 - type: entity
   parent: FoodBakingBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gave FoodDoughTortillaFlat its own reagents and set nutriment to 5.

## Why / Balance
Related to issue # 1419 in tracker: https://github.com/project-wayfarer/wayfarer-14/issues/1419

## Technical details
None needed.

## How to test
Go in game, make tortilla dough, slice and flatten, check regeant solutions via right click debug.

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)

## Breaking changes
N/A

**Changelog**
:cl:
- fix: Set FoodDoughTortillaFlat nutri to 5, was 15.