### PR TITLE
Ipc vore

### DIFF
--- a/Content.Server/FloofStation/VoreSystem.cs
+++ b/Content.Server/FloofStation/VoreSystem.cs
@@ -731,7 +731,14 @@ public sealed class VoreSystem : EntitySystem
             {
                 DamageSpecifier damage = new();
                 damage.DamageDict.Add("Caustic", 1);
-                _damageable.TryChangeDamage(uid, damage, true, false);
+
+                var damageDone = _damageable.TryChangeDamage(uid, damage, true, false); //Wayfarer: deal blunt damage if caustic is blocked, to allow digesting IPC. Amount is halved, to account for no crit state.
+                if (damageDone == null || damageDone.GetTotal() == 0)
+                {
+                    damage.DamageDict.Add("Blunt", 0.5f);
+                    _damageable.TryChangeDamage(uid, damage, true, false); 
+                }//End Wayfarer
+
 
                 // Give 1 Hunger per 1 Caustic Damage.
                 if (TryComp<HungerComponent>(vored.Pred, out var hunger))

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -4,7 +4,7 @@
   parent: [BaseMob, MobDamageable, MobCombat, MobAtmosExposed, MobFlammable]
   abstract: true
   components:
-    #- type: Vore # Floofstation - Vore # Wayfarer: Actually, not sure if this will work well given how they can't eat.
+    - type: Vore # Floofstation - Vore # Wayfarer: Actually, not sure if this will work well given how they can't eat.
     - type: ModifyUndies # Floofstation
 # Wayfarer: This is needed due to the unique base
     - type: Carriable

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -4,7 +4,7 @@
   parent: [BaseMob, MobDamageable, MobCombat, MobAtmosExposed, MobFlammable]
   abstract: true
   components:
-    - type: Vore # Floofstation - Vore # Wayfarer: Actually, not sure if this will work well given how they can't eat.
+    - type: Vore # Floofstation - Vore
     - type: ModifyUndies # Floofstation
 # Wayfarer: This is needed due to the unique base
     - type: Carriable


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Uncomments the Vore Component on IPCs, allowing them to eat and be eaten.
Also makes digestion deal 0.5 blunt damage to targets immune to Caustic, so IPCs can be digested (following a discussion of whether the community would prefer this or them staying immune).

## Why / Balance
https://github.com/project-wayfarer/wayfarer-14/issues/1221 resolves this issue, and also from a player (who shall be unnamed) who wants their IPC character to be able to vore.

## Technical details
Uncomments code in IPC definition.
Small modification to the VoreSystem

NOTES: Does not apply to Cyborgs. Still uses same language (body, stomach, acid). Future work could make IPC specific locale strings implying biofuel generation, possibly paired with a whole vore overhaul.

## How to test
Load world, spawn some IPCs and Non IPCs. Have Vore consent enabled.
Eat an IPC. Digest them. Should take about 2 minutes, with sparking starting halfway.
Eat a humanoid, confirm they take no additional blunt damage
control an IPC, confirm they can eat other entities


## Media
<img width="751" height="128" alt="Screenshot 2026-08-25 142334" src="https://github.com/user-attachments/assets/be57a8c7-8f00-4216-9f61-366c588539d6" />
<img width="272" height="167" alt="Screenshot 2026-08-25 142410" src="https://github.com/user-attachments/assets/976a9c84-37eb-4b5d-a5c3-c658c5844072" />
<img width="423" height="143" alt="Screenshot 2026-08-25 142424" src="https://github.com/user-attachments/assets/39445c83-a720-44f0-818e-49f2ef2ab9c3" />
<img width="526" height="71" alt="Screenshot 2026-08-25 144851" src="https://github.com/user-attachments/assets/c0f35fe8-19c1-4bd3-94f5-fdb68751330c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Should be none

**Changelog**
:cl:
- tweak: IPCs can now vore/digest, and be vored/digested.

