### PR TITLE
Make shadekin night vision permanent

### DIFF
--- a/Content.Server/_Starlight/Shadekin/ShadekinSystem.cs
+++ b/Content.Server/_Starlight/Shadekin/ShadekinSystem.cs
@@ -35,7 +35,6 @@ using Content.Server.Examine;
 using Robust.Server.GameObjects;
 using Content.Shared._Starlight.Shadekin.Components;
 using Content.Shared.Body.Events;
-using Content.Shared.Overlays; // Wayfarer
 // using Content.Shared._Starlight.Overlay.Components; // Wayfarer
 // using Content.Shared._Starlight.NullSpace.Components; // Wayfarer
 // using Content.Server._Starlight.Shadekin.Components; // Wayfarer
@@ -306,21 +305,23 @@ public sealed partial class ShadekinSystem : EntitySystem
         }
     }
 
-    private void ToggleNightVision(EntityUid uid, ShadekinState shadekinState)
-    {
-        var nightVision = EnsureComp<NightVisionComponent>(uid);
-        var shouldBeActive = shadekinState == ShadekinState.Dark;
+    // Wayfarer: No NightVision
+    // private void ToggleNightVision(EntityUid uid, ShadekinState shadekinState)
+    // {
+    //     var nightVision = EnsureComp<NightVisionComponent>(uid);
+    //     var shouldBeActive = shadekinState == ShadekinState.Dark;
 
-        // avoid dirtying if we don't need to
-        if (nightVision.Enabled == shouldBeActive) // Wayfarer: Active<Enabled
-            return;
+    //     // avoid dirtying if we don't need to
+    //     if (nightVision.Active == shouldBeActive)
+    //         return;
 
         // update whether or not nightVision should be active based on light level
         // nightVision.Enabled = shouldBeEnabled; // Wayfarer
 
-        // ensure nightVision updates to reflect the new state
-        Dirty(uid, nightVision);
-    }
+    //     // ensure nightVision updates to reflect the new state
+    //     Dirty(uid, nightVision);
+    // }
+    // End Wayfarer
 
     private void CheckThresholds(EntityUid uid, ShadekinComponent component, float lightExposure)
     {
@@ -403,7 +404,7 @@ public sealed partial class ShadekinSystem : EntitySystem
 
             CheckThresholds(uid, component, lightExposure);
 
-            ToggleNightVision(uid, component.CurrentState);
+            // ToggleNightVision(uid, component.CurrentState); // Wayfarer: No Nightvision
             SetPassiveBuff(uid, component.CurrentState);
             _speed.RefreshMovementSpeedModifiers(uid);
 

--- a/Content.Server/_Starlight/Shadekin/ShadekinSystem.cs
+++ b/Content.Server/_Starlight/Shadekin/ShadekinSystem.cs
@@ -316,7 +316,7 @@ public sealed partial class ShadekinSystem : EntitySystem
             return;
 
         // update whether or not nightVision should be active based on light level
-        nightVision.Enabled = shouldBeActive; // Wayfarer: Active<Enabled
+        // nightVision.Enabled = shouldBeEnabled; // Wayfarer
 
         // ensure nightVision updates to reflect the new state
         Dirty(uid, nightVision);

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/shadekin.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/shadekin.yml
@@ -164,3 +164,4 @@
           amount: 5
     - type: FireVisuals
       alternateState: Standing
+    - type: NightVision # Wayfarer


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Makes shadekin night vision not turn off when closer to something bright. It is very disorienting for night vision to toggle itself over and over.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
People were mentioning that it's disorienting
## Technical details
<!-- Summary of code changes for easier review. -->
Commented out one line of C# that handled shadekin night vision changing when in bright/dark places
## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="872" height="671" alt="image" src="https://github.com/user-attachments/assets/6524c6ce-ec3d-4a35-ab68-65e39ec5ed95" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [X] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Shadekin night vision doesn't turn off when exposed to light

