### PR TITLE
IPCs can now swap their own cells

### DIFF
--- a/Content.Shared/_EinsteinEngines/Silicon/SharedSiliconSystem.cs
+++ b/Content.Shared/_EinsteinEngines/Silicon/SharedSiliconSystem.cs
@@ -31,10 +31,10 @@ public sealed class SharedSiliconChargeSystem : EntitySystem
         if (args.Cancelled
             || !TryComp<PowerCellSlotComponent>(uid, out var cellSlotComp)
             || !_itemSlots.TryGetSlot(uid, cellSlotComp.CellSlotId, out var cellSlot)
-            || cellSlot != args.Slot || args.User != uid)
+            || cellSlot != args.Slot)
             return;
 
-        args.Cancelled = true;
+        //Wayfarer - Allows Siliccons to swap their own cells, to be more independent.
     }
 
     private void OnItemSlotEjectAttempt(EntityUid uid, SiliconComponent component, ref ItemSlotEjectAttemptEvent args)
@@ -42,10 +42,10 @@ public sealed class SharedSiliconChargeSystem : EntitySystem
         if (args.Cancelled
             || !TryComp<PowerCellSlotComponent>(uid, out var cellSlotComp)
             || !_itemSlots.TryGetSlot(uid, cellSlotComp.CellSlotId, out var cellSlot)
-            || cellSlot != args.Slot || args.User != uid)
+            || cellSlot != args.Slot)
             return;
 
-        args.Cancelled = true;
+        //Wayfarer - Allows Silicons to swap their own cells, to be more independent.
     }
 
     private void OnSiliconInit(EntityUid uid, SiliconComponent component, ComponentInit args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
IPCs can now swap their own cells, allowing 

## Why / Balance
Requested by Indigo (Stardust). It allows IPCs them to be a bit more independent of power grids (e.g. they can carry spare cells in their backpack)

## Technical details
Removes some conditions in SharedSiliconSystems to no longer check if the person inserting/ejecting cells is the owner of the slot
Despite the files name, does not seem to affect Borgs when testing.


## How to test
spawn an IPC.
check you can still switch its cells as another
Switch to it
Swap your own cell.


## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://wayfarer14.com/wiki/mapping-requirements) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
- [x] If my code is AI Assisted, I have read and agree to the [AI_POLICY.md](AI_POLICY.md)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: IPCs can now swap their own cells

